### PR TITLE
Feat add daemon configuration for server entity

### DIFF
--- a/HedgehogPanel/Domain/Entities/Server.cs
+++ b/HedgehogPanel/Domain/Entities/Server.cs
@@ -9,19 +9,19 @@ public class Server
     public byte? LocalId { get; private set; }
     public string Name { get; private set; }
     public string Hostname { get; private set; }
-    public int Port { get; private set; }
+    public int DaemonPort { get; private set; }
     public ServerStatus Status { get; private set; }
     public string? Description { get; private set; }
     public DateTime? LastSeen { get; private set; }
     public DateTime? CreatedAt { get; private set; }
     public uint RowVersion { get; set; }
 
-    public Server(Guid guid, string name, string hostname, int port = 22, ServerStatus status = ServerStatus.Unknown, byte? localId = null, string? description = null, DateTime? lastSeen = null, DateTime? createdAt = null, uint rowVersion = 0)
+    public Server(Guid guid, string name, string hostname, int daemonPort = 22, ServerStatus status = ServerStatus.Unknown, byte? localId = null, string? description = null, DateTime? lastSeen = null, DateTime? createdAt = null, uint rowVersion = 0)
     {
         Guid = guid;
         Name = name ?? throw new ArgumentNullException(nameof(name));
         Hostname = hostname ?? throw new ArgumentNullException(nameof(hostname));
-        Port = port;
+        DaemonPort = daemonPort;
         Status = status;
         LocalId = localId;
         Description = description;

--- a/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/Repositories/ServerRepository.cs
+++ b/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/Repositories/ServerRepository.cs
@@ -22,7 +22,7 @@ public class ServerRepository : IServerRepository
         using var conn = await _connectionFactory.CreateConnectionAsync();
         if (conn is not NpgsqlConnection npgsqlConn) throw new InvalidOperationException("Expected NpgsqlConnection");
 
-        const string sql = "SELECT uuid, name, description, created_at FROM servers WHERE uuid = @id LIMIT 1";
+        const string sql = "SELECT uuid, name, hostname, daemon_port, description, created_at FROM servers WHERE uuid = @id LIMIT 1";
         await using var cmd = new NpgsqlCommand(sql, npgsqlConn);
         cmd.Parameters.AddWithValue("@id", guid);
         await using var reader = await cmd.ExecuteReaderAsync();
@@ -36,7 +36,7 @@ public class ServerRepository : IServerRepository
         using var conn = await _connectionFactory.CreateConnectionAsync();
         if (conn is not NpgsqlConnection npgsqlConn) throw new InvalidOperationException("Expected NpgsqlConnection");
 
-        const string sql = "SELECT uuid, name, description, created_at FROM servers ORDER BY name LIMIT @limit OFFSET @offset";
+        const string sql = "SELECT uuid, name, hostname, daemon_port, description, created_at FROM servers ORDER BY name LIMIT @limit OFFSET @offset";
         await using var cmd = new NpgsqlCommand(sql, npgsqlConn);
         cmd.Parameters.AddWithValue("@limit", limit);
         cmd.Parameters.AddWithValue("@offset", offset);
@@ -55,11 +55,13 @@ public class ServerRepository : IServerRepository
         using var conn = await _connectionFactory.CreateConnectionAsync();
         if (conn is not NpgsqlConnection npgsqlConn) throw new InvalidOperationException("Expected NpgsqlConnection");
 
-        const string sql = "INSERT INTO servers (uuid, name, description) VALUES (@id, @n, @d)";
+        const string sql = "INSERT INTO servers (uuid, name, hostname, daemon_port, description) VALUES (@id, @n, @h, @p, @d)";
         await using var cmd = new NpgsqlCommand(sql, npgsqlConn);
         cmd.Parameters.AddWithValue("@id", server.Guid);
         cmd.Parameters.AddWithValue("@n", server.Name);
         cmd.Parameters.AddWithValue("@d", (object?)server.Description ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@h", server.Hostname);
+        cmd.Parameters.AddWithValue("@p", server.DaemonPort);
 
         return await cmd.ExecuteNonQueryAsync() > 0;
     }
@@ -69,9 +71,11 @@ public class ServerRepository : IServerRepository
         using var conn = await _connectionFactory.CreateConnectionAsync();
         if (conn is not NpgsqlConnection npgsqlConn) throw new InvalidOperationException("Expected NpgsqlConnection");
 
-        const string sql = "UPDATE servers SET name = @n, description = @d WHERE uuid = @id";
+        const string sql = "UPDATE servers SET name = @n, hostname = @h, daemon_port = @p, description = @d WHERE uuid = @id";
         await using var cmd = new NpgsqlCommand(sql, npgsqlConn);
         cmd.Parameters.AddWithValue("@n", server.Name);
+        cmd.Parameters.AddWithValue("@h", server.Hostname);
+        cmd.Parameters.AddWithValue("@p", server.DaemonPort);
         cmd.Parameters.AddWithValue("@d", (object?)server.Description ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@id", server.Guid);
 
@@ -95,7 +99,7 @@ public class ServerRepository : IServerRepository
         if (conn is not NpgsqlConnection npgsqlConn) throw new InvalidOperationException("Expected NpgsqlConnection");
 
         const string sql = @"
-            SELECT s.uuid, s.name, s.description, s.created_at 
+            SELECT s.uuid, s.name, s.hostname, s.daemon_port, s.description, s.created_at 
             FROM servers s
             JOIN server_owners so ON s.uuid = so.server_uuid
             WHERE so.user_uuid = @userGuid
@@ -122,7 +126,7 @@ public class ServerRepository : IServerRepository
         if (conn is not NpgsqlConnection npgsqlConn) throw new InvalidOperationException("Expected NpgsqlConnection");
 
         const string sql = @"
-            SELECT s.uuid, s.name, s.description, s.created_at 
+            SELECT s.uuid, s.name, s.hostname, s.daemon_port, s.description, s.created_at 
             FROM servers s
             LEFT JOIN server_owners so ON s.uuid = so.server_uuid
             WHERE so.server_uuid IS NULL
@@ -165,6 +169,13 @@ public class ServerRepository : IServerRepository
         using var conn = await _connectionFactory.CreateConnectionAsync();
         if (conn is not NpgsqlConnection npgsqlConn) throw new InvalidOperationException("Expected NpgsqlConnection");
 
+        // Check if server exists
+        const string checkSql = "SELECT EXISTS(SELECT 1 FROM servers WHERE uuid = @serverGuid)";
+        await using var checkCmd = new NpgsqlCommand(checkSql, npgsqlConn);
+        checkCmd.Parameters.AddWithValue("@serverGuid", serverGuid);
+        var existsObj = await checkCmd.ExecuteScalarAsync();
+        if (!(bool)(existsObj ?? false)) return false;
+
         const string sql = @"
             INSERT INTO server_owners (server_uuid, user_uuid)
             VALUES (@serverGuid, @userGuid)
@@ -182,13 +193,13 @@ public class ServerRepository : IServerRepository
         return new Server(
             guid: reader.GetGuid(0),
             name: reader.GetString(1),
-            hostname: "", // Hostname (not in DB)
-            port: 22, // Port (not in DB)
+            hostname: reader.GetString(2),
+            daemonPort: reader.GetInt32(3),
             status: Domain.Enums.ServerStatus.Unknown, // Status (not in DB)
             localId: null, // (not in DB yet)
-            description: reader.IsDBNull(2) ? null : reader.GetString(2),
+            description: reader.IsDBNull(4) ? null : reader.GetString(4),
             lastSeen: null, // (not in DB yet)
-            createdAt: reader.IsDBNull(3) ? (DateTime?)null : reader.GetDateTime(3)
+            createdAt: reader.IsDBNull(5) ? (DateTime?)null : reader.GetDateTime(5)
         );
     }
 }

--- a/create.sql
+++ b/create.sql
@@ -15,7 +15,7 @@
   ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═════╝ ╚═╝  ╚═╝╚══════╝╚══════╝
 
   Database Name:    hedgehogdb
-  Version:          1.2.0
+  Version:          1.2.1
   Created:          2026
   
   Description:      Database for Server Management System
@@ -93,6 +93,8 @@ CREATE TABLE nodes (
 CREATE TABLE servers (
                          uuid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
                          name VARCHAR NOT NULL,
+                         hostname VARCHAR NOT NULL,
+                         daemon_port int not null,
                          description TEXT,
                          node_uuid UUID,
                          created_at TIMESTAMP DEFAULT now(),
@@ -198,10 +200,10 @@ ON CONFLICT (username) DO NOTHING;
 SELECT * FROM users;
 
 -- Insert default servers
-INSERT INTO servers (name, description, created_at)
-VALUES ('Main Server', 'Primary production server', NOW()),
-       ('Backup Server', 'Backup and redundancy server', NOW()),
-       ('Development Server', 'Development and testing environment', NOW());
+INSERT INTO servers (name, description, hostname, daemon_port, created_at)
+VALUES ('Main Server', 'Primary production server', 'main.hedgehog.batacek.eu', 50051, NOW()),
+       ('Backup Server', 'Backup and redundancy server', 'backup.hedgehog.batacek.eu', 50051, NOW()),
+       ('Development Server', 'Development and testing environment', 'dev.hedgehog.batacek.eu', 50051, NOW());
 
 -- Assign servers to admin user (using subquery to get admin's UUID)
 INSERT INTO server_owners (server_uuid, user_uuid, group_uuid)


### PR DESCRIPTION
### Description

This PR extends the `Server` entity to support daemon configuration by adding `hostname` and `daemon_port` attributes. These properties enable proper management of gRPC daemon connections for each server.

### Changes

**Domain Model:**
- Renamed `Port` property to `DaemonPort` in the `Server` entity to clarify its purpose
- Updated constructor to use `daemonPort` parameter
- Added proper `hostname` persistence

**Database Schema:**
- Updated `servers` table schema to include `hostname` (VARCHAR) and `daemon_port` (INT) columns
- Bumped database version from 1.2.0 to 1.2.1

**Data Access Layer:**
- Extended all SQL queries in `ServerRepository` to select `hostname` and `daemon_port`:
  - `GetByIdAsync()` - retrieves server by ID
  - `ListAsync()` - lists servers with pagination
  - `ListByOwnerAsync()` - lists servers owned by a specific user
  - `ListUnownedAsync()` - lists unassigned servers
- Updated `CreateAsync()` to insert both `hostname` and `daemon_port`
- Updated `UpdateAsync()` to modify both `hostname` and `daemon_port`
- Enhanced `MapServer()` to correctly map database columns to entity properties
- Added validation in `AssignToUserAsync()` to check if server exists before assignment

**Seed Data:**
- Updated default server inserts to include realistic hostname and daemon port values (port 50051)

---
