### PR TITLE
Add UNIQUE constraint to Node names

### DIFF
--- a/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/Repositories/NodeRepository.cs
+++ b/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/Repositories/NodeRepository.cs
@@ -112,6 +112,16 @@ public class NodeRepository : INodeRepository
         using var conn = await _connectionFactory.CreateConnectionAsync();
         if (conn is not NpgsqlConnection npgsqlConn) throw new InvalidOperationException("Expected NpgsqlConnection");
 
+        // Check if node with same name already exists
+        const string checkSql = @"SELECT EXISTS(SELECT 1 FROM nodes WHERE name = @name)";
+        await using var checkCmd = new NpgsqlCommand(checkSql, npgsqlConn);
+        checkCmd.Parameters.AddWithValue("@name", node.Name);
+        var existsObj = await checkCmd.ExecuteScalarAsync();
+        if (existsObj != null && (bool)existsObj)
+        {
+            throw new InvalidOperationException($"Node with name '{node.Name}' already exists.");
+        }
+
         const string sql = "INSERT INTO nodes (uuid, name, ip_address, port, description, status, registration_token, last_seen) VALUES (@id, @name, @ip, @port, @desc, @status, @token, @lastSeen)";
         await using var cmd = new NpgsqlCommand(sql, npgsqlConn);
         cmd.Parameters.AddWithValue("@id", node.Guid);

--- a/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/Repositories/NodeRepository.cs
+++ b/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/Repositories/NodeRepository.cs
@@ -148,7 +148,17 @@ public class NodeRepository : INodeRepository
     {
         using var conn = await _connectionFactory.CreateConnectionAsync();
         if (conn is not NpgsqlConnection npgsqlConn) throw new InvalidOperationException("Expected NpgsqlConnection");
-
+        
+        // Check if node with same name already exists
+        const string checkSql = @"SELECT EXISTS(SELECT 1 FROM nodes WHERE name = @name)";
+        await using var checkCmd = new NpgsqlCommand(checkSql, npgsqlConn);
+        checkCmd.Parameters.AddWithValue("@name", node.Name);
+        var existsObj = await checkCmd.ExecuteScalarAsync();
+        if (existsObj != null && (bool)existsObj)
+        {
+            throw new InvalidOperationException($"Node with name '{node.Name}' already exists.");
+        }
+        
         const string sql = "UPDATE nodes SET name = @name, ip_address = @ip, port = @port, description = @desc, status = @status, registration_token = @token, last_seen = @lastSeen WHERE uuid = @id";
         await using var cmd = new NpgsqlCommand(sql, npgsqlConn);
         cmd.Parameters.AddWithValue("@name", node.Name);

--- a/create.sql
+++ b/create.sql
@@ -15,7 +15,7 @@
   ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═════╝ ╚═╝  ╚═╝╚══════╝╚══════╝
 
   Database Name:    hedgehogdb
-  Version:          1.2.1
+  Version:          1.2.2
   Created:          2026
   
   Description:      Database for Server Management System
@@ -79,7 +79,7 @@ CREATE TABLE user_groups (
 -- Nodes (Daemons)
 CREATE TABLE nodes (
                        uuid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-                       name VARCHAR NOT NULL,
+                       name VARCHAR NOT NULL UNIQUE,
                        ip_address VARCHAR NOT NULL,
                        port INT NOT NULL,
                        description TEXT,


### PR DESCRIPTION
This PR adds validation to ensure node names are unique within the system. The change includes both a database-level constraint and application-level duplicate checking.

### Changes
- **Database Schema** (`create.sql`):
  - Added `UNIQUE` constraint to the `nodes.name` column
  - Updated database version from `1.2.1` to `1.2.2`

- **Application Logic** (`NodeRepository.cs`):
  - Added duplicate name check in `CreateAsync()` and `UpdateAsyn()` method before inserting a new node
  - Queries the database to check if a node with the same name already exists
  - Throws `InvalidOperationException` with a descriptive message if a duplicate is found
  - Ensures data integrity at both the application and database levels

### Motivation
Prevents multiple nodes from having the same name, which could cause conflicts in the server management system and make node identification ambiguous.