### PR TITLE
New login page

### DIFF
--- a/HedgehogPanel/API/ApiEndpointsRegistrar.cs
+++ b/HedgehogPanel/API/ApiEndpointsRegistrar.cs
@@ -2,6 +2,7 @@ using HedgehogPanel.API.Auth;
 using HedgehogPanel.API.Servers;
 using HedgehogPanel.API.Admin;
 using HedgehogPanel.API.Nodes;
+using HedgehogPanel.API.Fonts;
 using HedgehogPanel.Application.Contracts.Logging;
 using HedgehogPanel.Infrastructure.Logging;
 using Microsoft.AspNetCore.Routing;
@@ -13,11 +14,12 @@ public static class ApiEndpointsRegistrar
     private static readonly ILoggerService Logger = HedgehogLogger.ForContext(typeof(ApiEndpointsRegistrar));
     public static IEndpointRouteBuilder MapApi(this IEndpointRouteBuilder endpoints)
     {
-        Logger.Information("Mapping API endpoints: Auth, Servers, Nodes and Admin...");
+        Logger.Information("Mapping API endpoints: Auth, Servers, Nodes, Admin and Fonts...");
         endpoints.MapAuthEndpoints();
         endpoints.MapServerEndpoints();
         endpoints.MapNodeEndpoints();
         endpoints.MapAdminEndpoints();
+        endpoints.MapFontEndpoints();
         Logger.Information("API endpoints mapped.");
         return endpoints;
     }

--- a/HedgehogPanel/API/Fonts/FontEndpoints.cs
+++ b/HedgehogPanel/API/Fonts/FontEndpoints.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace HedgehogPanel.API.Fonts;
+
+public static class FontEndpoints
+{
+    // Hardcoded font map: local filename → CDN URL (fallback when file not present locally)
+    private static readonly Dictionary<string, string> KnownFonts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["inter-latin.woff2"]     = "https://fonts.gstatic.com/s/inter/v20/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2",
+        ["inter-latin-ext.woff2"] = "https://fonts.gstatic.com/s/inter/v20/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa25L7SUc.woff2",
+    };
+
+    public static IEndpointRouteBuilder MapFontEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/fonts/{filename}", async (
+            string filename,
+            HttpContext ctx,
+            IWebHostEnvironment env,
+            IHttpClientFactory httpClientFactory) =>
+        {
+            // Only serve known fonts — prevents path traversal and enumeration
+            if (!KnownFonts.TryGetValue(filename, out var cdnUrl))
+                return Results.NotFound();
+
+            ctx.Response.Headers.CacheControl = "public, max-age=31536000, immutable";
+
+            var localPath = Path.Combine(env.ContentRootPath, "Web", "wwwroot", "fonts", filename);
+
+            if (File.Exists(localPath))
+            {
+                return Results.File(localPath, "font/woff2",
+                    entityTag: new Microsoft.Net.Http.Headers.EntityTagHeaderValue($"\"{filename}\""),
+                    enableRangeProcessing: false);
+            }
+
+            // File not present locally — proxy from CDN transparently
+            // (redirect would be blocked by CSP font-src 'self')
+            var client = httpClientFactory.CreateClient("FontProxy");
+            try
+            {
+                var bytes = await client.GetByteArrayAsync(cdnUrl);
+                return Results.Bytes(bytes, "font/woff2");
+            }
+            catch (HttpRequestException)
+            {
+                return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
+            }
+        })
+        .AllowAnonymous();
+
+        return endpoints;
+    }
+}

--- a/HedgehogPanel/Extensions/HedgehogStartupExtensions.cs
+++ b/HedgehogPanel/Extensions/HedgehogStartupExtensions.cs
@@ -173,6 +173,12 @@ public static class HedgehogStartupExtensions
             });
         });
 
+        builder.Services.AddHttpClient("FontProxy", client =>
+        {
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("HedgehogPanel/1.0 FontProxy");
+            client.Timeout = System.TimeSpan.FromSeconds(10);
+        });
+
         builder.Services.AddMemoryCache();
         builder.Services.AddScoped<IAccountLockoutService, AccountLockoutService>();
 

--- a/HedgehogPanel/Web/wwwroot/css/login.css
+++ b/HedgehogPanel/Web/wwwroot/css/login.css
@@ -1,0 +1,285 @@
+/* latin-ext (Czech etc.) */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url('/fonts/inter-latin-ext.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url('/fonts/inter-latin.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* ── Tokens ── */
+:root {
+  --bg:          oklch(0.155 0.005 80);
+  --bg-2:        oklch(0.185 0.005 80);
+  --surface:     oklch(0.205 0.005 80);
+  --surface-2:   oklch(0.235 0.006 80);
+  --line:        oklch(1 0 0 / 0.07);
+  --line-strong: oklch(1 0 0 / 0.13);
+  --text:        oklch(0.96 0.004 80);
+  --text-dim:    oklch(0.74 0.008 80);
+  --text-mute:   oklch(0.56 0.008 80);
+  --text-faint:  oklch(0.42 0.008 80);
+  --accent:      oklch(0.68 0.12 130);
+  --accent-2:    oklch(0.80 0.10 130);
+  --accent-bg:   oklch(0.32 0.08 130 / 0.25);
+  --accent-ring: oklch(0.68 0.12 130 / 0.30);
+  --danger:      oklch(0.70 0.17 26);
+  --danger-2:    oklch(0.82 0.14 26);
+  --danger-bg:   oklch(0.32 0.10 26 / 0.24);
+  --font-ui:     "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono:   ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+/* ── Reset / base ── */
+* { box-sizing: border-box; }
+html, body { height: 100%; margin: 0; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+button, input { font: inherit; color: inherit; }
+button { cursor: pointer; }
+
+/* ── Login stage ── */
+.login-stage {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  background: var(--bg);
+}
+@media (max-width: 880px) { .login-stage { grid-template-columns: 1fr; } }
+
+/* ── Left poster column ── */
+.login-poster {
+  position: relative;
+  padding: 36px;
+  display: flex; flex-direction: column; justify-content: space-between;
+  background:
+    radial-gradient(700px 400px at 25% 30%, var(--accent-bg), transparent 60%),
+    radial-gradient(500px 360px at 80% 80%, oklch(0.4 0.05 80 / 0.3), transparent 60%),
+    linear-gradient(160deg, var(--bg-2), var(--bg));
+  border-right: 1px solid var(--line);
+  overflow: hidden;
+}
+.login-poster::before {
+  content: "";
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(var(--line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mask-image: radial-gradient(600px 500px at 30% 40%, #000, transparent 70%);
+  opacity: 0.6;
+}
+.login-poster > * { position: relative; z-index: 1; }
+@media (max-width: 880px) { .login-poster { display: none; } }
+
+.poster-head { display: flex; align-items: center; gap: 10px; }
+.poster-head .brand-mark {
+  font-size: 26px;
+  line-height: 1;
+  user-select: none;
+}
+.poster-head h1 { margin: 0; font-size: 18px; font-weight: 700; letter-spacing: -0.01em; flex: 1; }
+
+.lang-switch {
+  display: flex; gap: 4px; align-items: center;
+  margin-left: auto;
+}
+.lang-btn {
+  padding: 3px 8px;
+  border-radius: 5px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-mute);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--font-ui);
+  cursor: pointer;
+  transition: background .12s, color .12s, border-color .12s;
+}
+.lang-btn:hover { background: var(--surface); color: var(--text-dim); }
+.lang-btn.active {
+  background: var(--surface);
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+
+.poster-body { margin-top: 80px; }
+
+.login-wordmark {
+  font-size: clamp(56px, 8vw, 110px);
+  font-weight: 800;
+  letter-spacing: -0.06em;
+  line-height: 1.1;
+  padding-bottom: 0.08em;
+  margin: 0 0 8px;
+  background: linear-gradient(150deg, var(--accent-2) 0%, var(--accent) 60%, var(--text-dim) 130%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.login-wordmark .dot {
+  display: inline-block;
+  width: 0.16em; height: 0.16em;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-left: 0.03em;
+  margin-bottom: 0.02em;
+  vertical-align: baseline;
+  box-shadow: 0 0 30px var(--accent);
+  -webkit-text-fill-color: initial;
+}
+
+.login-tagline {
+  font-size: clamp(20px, 2.4vw, 28px);
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  margin: 24px 0 12px;
+  color: var(--text);
+  line-height: 1.2;
+  max-width: none;
+}
+
+.login-subline {
+  color: var(--text-mute);
+  font-size: 13.5px;
+  line-height: 1.55;
+  max-width: 40ch;
+  margin: 0;
+}
+
+.login-spikes {
+  display: flex; gap: 6px;
+  margin-top: 32px;
+  align-items: flex-end;
+  opacity: 0.7;
+}
+.login-spikes i {
+  display: block;
+  width: 3px;
+  border-radius: 2px;
+  background: var(--accent);
+}
+.login-spikes i:nth-child(1) { height: 10px; background: var(--text-faint); }
+.login-spikes i:nth-child(2) { height: 16px; background: var(--text-mute); }
+.login-spikes i:nth-child(3) { height: 24px; background: var(--text-dim); }
+.login-spikes i:nth-child(4) { height: 34px; }
+.login-spikes i:nth-child(5) { height: 28px; }
+.login-spikes i:nth-child(6) { height: 38px; background: var(--accent-2); }
+.login-spikes i:nth-child(7) { height: 22px; }
+.login-spikes i:nth-child(8) { height: 14px; background: var(--text-dim); }
+.login-spikes i:nth-child(9) { height: 8px;  background: var(--text-faint); }
+
+.poster-foot {
+  font-size: 12px; color: var(--text-mute);
+  font-family: var(--font-mono);
+  display: flex; gap: 12px; align-items: center;
+}
+.poster-foot::before {
+  content: "";
+  display: block; width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+
+/* ── Right form column ── */
+.login-form-wrap {
+  display: grid; place-items: center;
+  padding: 40px 24px;
+}
+.login-card {
+  width: 100%; max-width: 380px;
+  display: flex; flex-direction: column; gap: 18px;
+}
+.login-card h3 { margin: 0; font-size: 22px; font-weight: 700; letter-spacing: -0.015em; }
+.login-card .sub { color: var(--text-mute); font-size: 13.5px; margin-top: -10px; }
+.login-card form { display: flex; flex-direction: column; gap: 12px; }
+
+/* ── Form elements ── */
+.field { display: flex; flex-direction: column; gap: 6px; }
+.field label {
+  font-size: 12px;
+  color: var(--text-dim);
+  font-weight: 500;
+}
+.input {
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  color: var(--text);
+  padding: 9px 11px;
+  border-radius: 8px;
+  outline: none;
+  transition: border-color .12s, box-shadow .12s, background .12s;
+  font-size: 13px;
+  width: 100%;
+}
+.input:hover { border-color: var(--line-strong); }
+.input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+.input::placeholder { color: var(--text-faint); }
+
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+  padding: 9px 13px;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 500;
+  font-size: 13px;
+  transition: background .12s, border-color .12s, transform .08s;
+  white-space: nowrap;
+  width: 100%;
+}
+.btn:hover { background: var(--surface-2); border-color: var(--line-strong); }
+.btn:active { transform: translateY(1px); }
+.btn.primary {
+  background: var(--accent);
+  color: oklch(0.14 0.02 80);
+  border-color: oklch(0 0 0 / 0.25);
+  font-weight: 600;
+  padding: 11px 14px;
+}
+.btn.primary:hover { background: var(--accent-2); }
+.btn[disabled] { opacity: .5; cursor: not-allowed; }
+
+.ext-help {
+  font-size: 12px; color: var(--text-mute); text-align: center;
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+.ext-help code {
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+  background: var(--surface);
+  padding: 1px 5px; border-radius: 4px;
+}
+
+.error-msg {
+  font-size: 13px;
+  color: var(--danger-2);
+  background: var(--danger-bg);
+  border: 1px solid var(--danger);
+  border-radius: 8px;
+  padding: 9px 12px;
+  display: none;
+}

--- a/HedgehogPanel/Web/wwwroot/login.html
+++ b/HedgehogPanel/Web/wwwroot/login.html
@@ -4,94 +4,129 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Sign in · Hedgehog Panel</title>
-  <link rel="stylesheet" href="/html/css/style.css" />
-  <style>
-    .login-wrap {
-      min-height: 100vh;
-      display: grid;
-      place-items: center;
-      padding: 24px;
-      background: radial-gradient(1000px 600px at 20% -10%, rgba(122,46,42,0.12), transparent 50%),
-                  radial-gradient(800px 500px at 80% -10%, rgba(85,107,47,0.12), transparent 45%),
-                  var(--bg);
-    }
-    .login-card {
-      width: 100%;
-      max-width: 420px;
-      background: var(--panel);
-      border: 1px solid rgba(255,255,255,0.06);
-      border-radius: var(--radius);
-      padding: 20px 18px 18px 18px;
-      box-shadow: var(--shadow);
-    }
-    .brand {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      margin-bottom: 14px;
-    }
-    .brand .brand-logo { width: 28px; height: 28px; border-radius: 6px; background: radial-gradient(circle at 30% 30%, #c85c52, var(--accent-red)); box-shadow: inset 0 0 0 1px rgba(0,0,0,0.4), 0 2px 10px rgba(0,0,0,0.35); }
-    .brand .brand-title { font-weight: 700; letter-spacing: .5px; }
-
-    .field { margin-top: 12px; }
-    .label { display: block; font-size: 13px; color: var(--muted); margin-bottom: 6px; }
-    .input {
-      width: 100%;
-      padding: 10px 12px;
-      color: var(--text);
-      background: var(--panel-2);
-      border: 1px solid rgba(255,255,255,0.08);
-      border-radius: 10px;
-      outline: none;
-      transition: border-color .15s ease, box-shadow .15s ease;
-      font: inherit;
-    }
-    .input:focus { border-color: rgba(0,0,153,0.35); box-shadow: 0 0 0 3px rgba(0,0,153,0.18); }
-
-    .button {
-      width: 100%;
-      margin-top: 14px;
-      padding: 11px 14px;
-      background: linear-gradient(180deg, #22262c, #1b1f24);
-      color: var(--text);
-      border: 1px solid rgba(255,255,255,0.10);
-      border-radius: 10px;
-      cursor: pointer;
-      font: inherit;
-      transition: transform .12s ease, border-color .12s ease, background .12s ease;
-    }
-    .button:hover { transform: translateY(-1px); border-color: rgba(255,255,255,0.18); }
-
-    .error { margin-top: 10px; color: #f2b2ae; font-size: 14px; display: none; }
-    .hint { margin-top: 8px; color: var(--muted); font-size: 12px; }
-  </style>
+  <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/fonts/inter-latin-ext.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="stylesheet" href="/html/css/login.css">
 </head>
 <body>
-  <div class="login-wrap">
-    <div class="login-card">
-      <div class="brand">
-        <div class="brand-logo" aria-hidden="true"></div>
-        <div class="brand-title">Hedgehog Panel</div>
+  <div class="login-stage">
+    <!-- Left decorative column -->
+    <div class="login-poster">
+      <div class="poster-head">
+        <span class="brand-mark" aria-hidden="true">🦔</span>
+        <h1>Hedgehog Panel</h1>
+        <div class="lang-switch">
+          <button class="lang-btn active" data-lang="en">EN</button>
+          <button class="lang-btn" data-lang="cs">CS</button>
+        </div>
       </div>
-      <h2 style="margin: 0 0 8px 0;">Sign in</h2>
-      <p class="hint">Use username "admin" or "default_user".</p>
 
-      <form id="login-form" novalidate>
-        <div class="field">
-          <label class="label" for="username">Username</label>
-          <input class="input" id="username" name="username" type="text" autocomplete="username" required />
+      <div class="poster-body">
+        <p class="login-wordmark">hedgehog<span class="dot"></span></p>
+        <p class="login-tagline" id="lbl-tagline">Server management, simplified.</p>
+        <p class="login-subline" id="lbl-subline">Monitor services, manage nodes, and control your infrastructure from one place.</p>
+        <div class="login-spikes" aria-hidden="true">
+          <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
         </div>
-        <div class="field">
-          <label class="label" for="password">Password</label>
-          <input class="input" id="password" name="password" type="password" autocomplete="current-password" required />
+      </div>
+
+      <div class="poster-foot">Hedgehog Panel · v1.2.2 · Batacek.eu</div>
+    </div>
+
+    <!-- Right form column -->
+    <div class="login-form-wrap">
+      <div class="login-card">
+        <h3 id="lbl-heading">Sign in</h3>
+        <p class="sub" id="lbl-sub">Enter your credentials to continue.</p>
+
+        <form id="login-form" novalidate>
+          <div class="field">
+            <label for="username" id="lbl-username">Username</label>
+            <input class="input" id="username" name="username" type="text" autocomplete="username" required />
+          </div>
+          <div class="field">
+            <label for="password" id="lbl-password">Password</label>
+            <input class="input" id="password" name="password" type="password" autocomplete="current-password" required />
+          </div>
+          <div id="error" class="error-msg" role="alert"></div>
+          <button class="btn primary" type="submit" id="lbl-submit">Sign in</button>
+        </form>
+
+        <div class="ext-help" id="lbl-help">
+          Default credentials: <code>admin</code> / <code>admin123</code>
         </div>
-        <button class="button" type="submit">Sign in</button>
-        <div id="error" class="error" role="alert"></div>
-      </form>
+      </div>
     </div>
   </div>
 
   <script>
+    const i18n = {
+      en: {
+        title:    'Sign in · Hedgehog Panel',
+        heading:  'Sign in',
+        sub:      'Enter your credentials to continue.',
+        username: 'Username',
+        password: 'Password',
+        submit:   'Sign in',
+        help:     'Default credentials: <code>admin</code> / <code>admin123</code>',
+        tagline:  'Infrastructure management, simplified.',
+        subline:  'Monitor services, manage nodes, and control your infrastructure from one place.',
+        errBoth:  'Please enter both username and password.',
+        errServer:'Server error. Please try again.',
+        errNet:   'Unable to contact the server.',
+        errRate:  'Too many requests. Please wait before trying again.',
+        lblLocked:'Locked',
+        lblRate:  'Rate limited',
+      },
+      cs: {
+        title:    'Přihlášení · Hedgehog Panel',
+        heading:  'Přihlásit se',
+        sub:      'Zadejte přihlašovací údaje pro pokračení.',
+        username: 'Uživatelské jméno',
+        password: 'Heslo',
+        submit:   'Přihlásit se',
+        help:     'Výchozí přihlašovací údaje: <code>admin</code> / <code>admin123</code>',
+        tagline:  'Správa infrastruktury, zjednodušeně.',
+        subline:  'Sledujte služby, spravujte uzly a ovládejte infrastrukturu z jednoho místa.',
+        errBoth:  'Zadejte prosím uživatelské jméno i heslo.',
+        errServer:'Chyba serveru. Zkuste to prosím znovu.',
+        errNet:   'Nelze se spojit se serverem.',
+        errRate:  'Příliš mnoho požadavků. Chvíli počkejte.',
+        lblLocked:'Uzamčeno',
+        lblRate:  'Omezeno',
+      }
+    };
+
+    let currentLang = localStorage.getItem('hp-lang') || 'en';
+
+    function setLang(lang) {
+      if (!i18n[lang]) return;
+      currentLang = lang;
+      localStorage.setItem('hp-lang', lang);
+
+      const t = i18n[lang];
+      document.title = t.title;
+      document.getElementById('lbl-heading').textContent  = t.heading;
+      document.getElementById('lbl-sub').textContent      = t.sub;
+      document.getElementById('lbl-username').textContent = t.username;
+      document.getElementById('lbl-password').textContent = t.password;
+      document.getElementById('lbl-submit').textContent   = t.submit;
+      document.getElementById('lbl-help').innerHTML       = t.help;
+      document.getElementById('lbl-tagline').innerHTML    = t.tagline;
+      document.getElementById('lbl-subline').textContent  = t.subline;
+
+      document.querySelectorAll('.lang-btn').forEach(b => {
+        b.classList.toggle('active', b.dataset.lang === lang);
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      setLang(currentLang);
+      document.querySelectorAll('.lang-btn').forEach(btn => {
+        btn.addEventListener('click', () => setLang(btn.dataset.lang));
+      });
+    });
+
     (function() {
       const form = document.getElementById('login-form');
       const errorEl = document.getElementById('error');
@@ -114,7 +149,7 @@
             clearInterval(countdownTimer);
             countdownTimer = null;
             btn.disabled = false;
-            btn.textContent = 'Sign in';
+            btn.textContent = i18n[currentLang].submit;
           }
         }, 1000);
 
@@ -133,9 +168,8 @@
         clearError();
         const username = document.getElementById('username').value.trim();
         const password = document.getElementById('password').value;
-        if (!username || !password) { showError('Please enter both username and password.'); return; }
-        
-        // Read Antiforgery token from cookie
+        if (!username || !password) { showError(i18n[currentLang].errBoth); return; }
+
         const xsrfToken = document.cookie.split('; ')
           .find(row => row.startsWith('XSRF-TOKEN='))
           ?.split('=')
@@ -145,7 +179,7 @@
         try {
           const res = await fetch('/api/login', {
             method: 'POST',
-            headers: { 
+            headers: {
               'Content-Type': 'application/json',
               'X-CSRF-Token': xsrfToken || ''
             },
@@ -161,20 +195,19 @@
             const data = await res.json().catch(() => ({}));
             const remain = (data && typeof data.lockoutTimeRemaining === 'string') ? data.lockoutTimeRemaining : null;
             showError((data && data.error) || 'Account locked due to too many failed attempts.');
-            // Parse mm:ss -> seconds
             let seconds = 0;
             if (remain && /\d{2}:\d{2}/.test(remain)) {
               const [m,s] = remain.split(':').map(x => parseInt(x,10));
               seconds = (m*60 + s) || 0;
             }
-            if (seconds > 0) disableWithCountdown(seconds, 'Locked');
+            if (seconds > 0) disableWithCountdown(seconds, i18n[currentLang].lblLocked);
             return;
           }
 
           if (res.status === 429) {
             const retryAfter = parseInt(res.headers.get('Retry-After') || '0', 10);
-            showError('Too many requests. Please wait before trying again.');
-            if (retryAfter > 0) disableWithCountdown(retryAfter, 'Rate limited');
+            showError(i18n[currentLang].errRate);
+            if (retryAfter > 0) disableWithCountdown(retryAfter, i18n[currentLang].lblRate);
             return;
           }
 
@@ -185,15 +218,15 @@
             const data = await res.json().catch(() => ({}));
             showError((data && data.error) || 'Invalid username or password.');
           } else {
-            showError('Server error. Please try again.');
+            showError(i18n[currentLang].errServer);
           }
         } catch (err) {
-          showError('Unable to contact the server.');
+          showError(i18n[currentLang].errNet);
         }
       });
 
       document.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' && (document.activeElement === document.body)) {
+        if (e.key === 'Enter' && document.activeElement === document.body) {
           form.requestSubmit();
         }
       });


### PR DESCRIPTION

This PR introduces a redesigned login page as the first step of the ongoing frontend redesign.

**What's changed**
- Replaced the old single-column login card with a modern two-column layout — a decorative poster panel on the left and the sign-in form on the right
- New design system with CSS custom properties (oklch color tokens, Inter variable font)
- EN/CS language switcher with `localStorage` persistence
- Font serving via a new `GET /fonts/{filename}` backend endpoint that transparently proxies from Google CDN when files aren't present locally — making the panel usable in air-gapped/lab environments without any extra setup
- CSS extracted into `css/login.css` to keep the HTML clean
- All original login logic preserved: CSRF token, lockout countdown, rate-limit handling

**Notes**
- This branch (`New_Frontend`) will remain open — more pages are being migrated in the near future, this is just the first piece
- UI/UX design was made by [Claude Design (Opus 4.7)](https://www.anthropic.com/news/claude-design-anthropic-labs)
- Backend and infrastructure by @Batacek 