### PR TITLE
Add automated test suite (HedgehogPanel.Tests)

### DIFF
--- a/HedgehogPanel.Tests/HedgehogPanel.Tests.csproj
+++ b/HedgehogPanel.Tests/HedgehogPanel.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit" Version="2.5.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\HedgehogPanel\HedgehogPanel.csproj" />
+    </ItemGroup>
+
+</Project>
+

--- a/HedgehogPanel.Tests/HedgehogPanel.Tests.csproj
+++ b/HedgehogPanel.Tests/HedgehogPanel.Tests.csproj
@@ -11,6 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.22" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.5.3" />
@@ -25,6 +26,7 @@
     <ItemGroup>
         <ProjectReference Include="..\HedgehogPanel\HedgehogPanel.csproj" />
     </ItemGroup>
+
 
 </Project>
 

--- a/HedgehogPanel.Tests/Integration/Endpoints/AccountLockoutEndpointTests.cs
+++ b/HedgehogPanel.Tests/Integration/Endpoints/AccountLockoutEndpointTests.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Endpoints;
+
+/// <summary>
+/// Verifies the account lockout flow end-to-end: repeated failed logins for the same
+/// user lock the account and the login endpoint starts returning 423 Locked.
+/// Uses a dedicated factory so its rate-limit/lockout state is isolated.
+/// </summary>
+[Collection("IntegrationTests")]
+public class AccountLockoutEndpointTests : IClassFixture<AccountLockoutEndpointTests.LockoutFactory>
+{
+    private readonly PostgreSqlFixture _db;
+    private readonly LockoutFactory _factory;
+
+    public AccountLockoutEndpointTests(PostgreSqlFixture db, LockoutFactory factory)
+    {
+        _db = db;
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task RepeatedFailedLogins_LockTheAccount_Returning423()
+    {
+        await _db.CleanDatabaseAsync();
+        var user = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, "lockout_user");
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var sawLocked = false;
+        for (var i = 0; i < 6; i++)
+        {
+            var response = await client.PostAsJsonAsync("/api/login",
+                new { username = user.Username, password = "definitely-wrong" });
+            if (response.StatusCode == HttpStatusCode.Locked)
+            {
+                sawLocked = true;
+                break;
+            }
+        }
+
+        Assert.True(sawLocked, "Expected the account to be locked (423) after repeated failed logins.");
+    }
+
+    /// <summary>Dedicated factory so this class has its own lockout/rate-limit partition.</summary>
+    public sealed class LockoutFactory : HedgehogWebApplicationFactory
+    {
+    }
+}

--- a/HedgehogPanel.Tests/Integration/Endpoints/AdminEndpointsTests.cs
+++ b/HedgehogPanel.Tests/Integration/Endpoints/AdminEndpointsTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using HedgehogPanel.Infrastructure.Persistence.PostgreSQL.Repositories;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Endpoints;
+
+/// <summary>End-to-end tests for the admin endpoints (/api/admin/*), including the Admin role guard.</summary>
+[Collection("IntegrationTests")]
+public class AdminEndpointsTests : IClassFixture<HedgehogWebApplicationFactory>
+{
+    private readonly PostgreSqlFixture _db;
+    private readonly HedgehogWebApplicationFactory _factory;
+
+    public AdminEndpointsTests(PostgreSqlFixture db, HedgehogWebApplicationFactory factory)
+    {
+        _db = db;
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task AdminUsers_WhenNotAuthenticated_IsRejected()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.GetAsync("/api/admin/users");
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found or HttpStatusCode.Unauthorized,
+            $"Expected redirect or 401 but got {(int)response.StatusCode}.");
+    }
+
+    [Fact]
+    public async Task AdminUsers_WhenAuthenticatedAsNonAdmin_ReturnsForbidden()
+    {
+        await _db.CleanDatabaseAsync();
+        var user = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, "plain_user");
+        var client = EndpointTestSupport.NewClient(_factory);
+        await EndpointTestSupport.LoginAsync(client, user.Username);
+
+        var response = await client.GetAsync("/api/admin/users");
+
+        // An authenticated non-admin is denied. The cookie handler surfaces an authorization
+        // failure as a redirect (to the access-denied/login path) rather than a bare 403,
+        // so accept either — the key property is that access is not granted (no 200).
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Redirect or HttpStatusCode.Found,
+            $"Expected forbidden or redirect but got {(int)response.StatusCode}.");
+    }
+
+    [Fact]
+    public async Task AdminUsers_WhenAuthenticatedAsAdmin_ReturnsUserList()
+    {
+        var (client, admin) = await AdminClientAsync("admin_list");
+
+        var response = await client.GetAsync("/api/admin/users");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var usernames = body.EnumerateArray().Select(e => e.GetProperty("username").GetString()).ToList();
+        Assert.Contains(admin.Username, usernames);
+    }
+
+    [Fact]
+    public async Task AdminCreateUser_WithValidData_ReturnsOk()
+    {
+        var (client, _) = await AdminClientAsync("admin_create");
+
+        var newUsername = $"created_{Guid.NewGuid():N}".Substring(0, 24);
+        var response = await client.PostAsJsonAsync("/api/admin/users", new
+        {
+            username = newUsername,
+            email = $"{newUsername}@hedgehog.batacek.eu",
+            password = EndpointTestSupport.Password,
+            firstName = "New",
+            middleName = (string?)null,
+            lastName = "User"
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminCreateUser_WithShortPassword_ReturnsBadRequest()
+    {
+        var (client, _) = await AdminClientAsync("admin_weakpass");
+
+        var response = await client.PostAsJsonAsync("/api/admin/users", new
+        {
+            username = $"weak_{Guid.NewGuid():N}".Substring(0, 20),
+            email = "weak@hedgehog.batacek.eu",
+            password = "short",
+            firstName = (string?)null,
+            middleName = (string?)null,
+            lastName = (string?)null
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminDeleteUser_WhenExists_ReturnsOk()
+    {
+        var (client, _) = await AdminClientAsync("admin_del");
+        var victim = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, "victim");
+
+        var response = await client.DeleteAsync($"/api/admin/users/{victim.Username}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminDeleteUser_BuiltInAdmin_ReturnsBadRequest()
+    {
+        var (client, _) = await AdminClientAsync("admin_protect");
+
+        var response = await client.DeleteAsync("/api/admin/users/admin");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminCreateServer_WithName_ReturnsOk()
+    {
+        var (client, _) = await AdminClientAsync("admin_srv_create");
+
+        var response = await client.PostAsJsonAsync("/api/admin/servers",
+            new { name = "AdminServer", description = "via admin", ownerUsername = (string?)null });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminCreateServer_WithoutName_ReturnsBadRequest()
+    {
+        var (client, _) = await AdminClientAsync("admin_srv_noname");
+
+        var response = await client.PostAsJsonAsync("/api/admin/servers",
+            new { name = "", description = (string?)null, ownerUsername = (string?)null });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AdminDeleteServer_WhenExists_ReturnsOk()
+    {
+        var (client, _) = await AdminClientAsync("admin_srv_del");
+
+        var serverRepository = new ServerRepository(new EndpointTestConnectionFactory(_db.ConnectionString));
+        var server = TestDataBuilder.CreateTestServer("ToDelete", "todelete.hedgehog.batacek.eu");
+        await serverRepository.CreateAsync(server);
+
+        var response = await client.DeleteAsync($"/api/admin/servers/{server.Guid}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>Cleans the DB, seeds an admin, logs in and returns the authenticated client + admin account.</summary>
+    private async Task<(HttpClient client, HedgehogPanel.Domain.Entities.Account admin)> AdminClientAsync(string prefix)
+    {
+        await _db.CleanDatabaseAsync();
+        var admin = await EndpointTestSupport.SeedAdminAsync(_db.ConnectionString, prefix);
+        var client = EndpointTestSupport.NewClient(_factory);
+        await EndpointTestSupport.LoginAsync(client, admin.Username);
+        return (client, admin);
+    }
+}

--- a/HedgehogPanel.Tests/Integration/Endpoints/AdminValidationTests.cs
+++ b/HedgehogPanel.Tests/Integration/Endpoints/AdminValidationTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Endpoints;
+
+/// <summary>
+/// Validation and additional read paths of the admin endpoints. Uses its own factory
+/// instance so its login rate limit is isolated from AdminEndpointsTests.
+/// </summary>
+[Collection("IntegrationTests")]
+public class AdminValidationTests : IClassFixture<HedgehogWebApplicationFactory>
+{
+    private readonly PostgreSqlFixture _db;
+    private readonly HedgehogWebApplicationFactory _factory;
+
+    public AdminValidationTests(PostgreSqlFixture db, HedgehogWebApplicationFactory factory)
+    {
+        _db = db;
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task CreateUser_WithDuplicateEmail_ReturnsConflict()
+    {
+        var client = await AdminClientAsync("adminval_dupemail");
+        var email = $"dup_{Guid.NewGuid():N}@hedgehog.batacek.eu";
+
+        var first = await client.PostAsJsonAsync("/api/admin/users", new
+        {
+            username = $"first_{Guid.NewGuid():N}".Substring(0, 20),
+            email,
+            password = EndpointTestSupport.Password,
+            firstName = (string?)null, middleName = (string?)null, lastName = (string?)null
+        });
+        first.EnsureSuccessStatusCode();
+
+        var duplicate = await client.PostAsJsonAsync("/api/admin/users", new
+        {
+            username = $"second_{Guid.NewGuid():N}".Substring(0, 20),
+            email,
+            password = EndpointTestSupport.Password,
+            firstName = (string?)null, middleName = (string?)null, lastName = (string?)null
+        });
+
+        Assert.Equal(HttpStatusCode.Conflict, duplicate.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateUser_WithInvalidUsernameCharacters_ReturnsBadRequest()
+    {
+        var client = await AdminClientAsync("adminval_badname");
+
+        var response = await client.PostAsJsonAsync("/api/admin/users", new
+        {
+            username = "bad name!",
+            email = "x@hedgehog.batacek.eu",
+            password = EndpointTestSupport.Password,
+            firstName = (string?)null, middleName = (string?)null, lastName = (string?)null
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnlockUser_ReturnsOk()
+    {
+        var client = await AdminClientAsync("adminval_unlock");
+
+        var response = await client.PostAsJsonAsync("/api/admin/users/someuser/unlock",
+            new { clientIp = "1.2.3.4" });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetServers_AsAdmin_ReturnsOk()
+    {
+        var client = await AdminClientAsync("adminval_servers");
+
+        var response = await client.GetAsync("/api/admin/servers");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    private async Task<HttpClient> AdminClientAsync(string prefix)
+    {
+        await _db.CleanDatabaseAsync();
+        var admin = await EndpointTestSupport.SeedAdminAsync(_db.ConnectionString, prefix);
+        var client = EndpointTestSupport.NewClient(_factory);
+        await EndpointTestSupport.LoginAsync(client, admin.Username);
+        return client;
+    }
+}

--- a/HedgehogPanel.Tests/Integration/Endpoints/AntiforgeryTests.cs
+++ b/HedgehogPanel.Tests/Integration/Endpoints/AntiforgeryTests.cs
@@ -1,0 +1,36 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Endpoints;
+
+/// <summary>
+/// Verifies CSRF protection is enforced. Uses the factory variant that keeps the real
+/// antiforgery middleware active (no no-op stub), so a state-changing request without a
+/// valid token must be rejected.
+/// </summary>
+[Collection("IntegrationTests")]
+public class AntiforgeryTests : IClassFixture<AntiforgeryEnabledWebApplicationFactory>
+{
+    private readonly AntiforgeryEnabledWebApplicationFactory _factory;
+
+    public AntiforgeryTests(AntiforgeryEnabledWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Post_WithoutCsrfToken_IsRejected()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        // No prior GET to obtain the XSRF-TOKEN cookie and no X-CSRF-Token header.
+        var response = await client.PostAsJsonAsync("/api/login",
+            new { username = "someone", password = EndpointTestSupport.Password });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/HedgehogPanel.Tests/Integration/Endpoints/AuthEndpointsTests.cs
+++ b/HedgehogPanel.Tests/Integration/Endpoints/AuthEndpointsTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Endpoints;
+
+/// <summary>
+/// End-to-end tests for the auth endpoints (/api/login, /api/logout, /api/me)
+/// running the real application against the test PostgreSQL database.
+/// </summary>
+[Collection("IntegrationTests")]
+public class AuthEndpointsTests : IClassFixture<HedgehogWebApplicationFactory>
+{
+    private readonly PostgreSqlFixture _db;
+    private readonly HedgehogWebApplicationFactory _factory;
+
+    public AuthEndpointsTests(PostgreSqlFixture db, HedgehogWebApplicationFactory factory)
+    {
+        _db = db;
+        _factory = factory;
+    }
+
+    // ----- /api/login -----
+
+    [Fact]
+    public async Task Login_WithValidCredentials_ReturnsOk()
+    {
+        await _db.CleanDatabaseAsync();
+        var user = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, "login_valid");
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.PostAsJsonAsync("/api/login", new { username = user.Username, password = EndpointTestSupport.Password });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Contains(response.Headers.GetValues("Set-Cookie"),
+            c => c.StartsWith("HedgehogAuth", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Login_WithInvalidPassword_ReturnsUnauthorized()
+    {
+        await _db.CleanDatabaseAsync();
+        var user = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, "login_badpass");
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.PostAsJsonAsync("/api/login", new { username = user.Username, password = "wrong-password" });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithMissingCredentials_ReturnsBadRequest()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.PostAsJsonAsync("/api/login", new { username = "", password = "" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithNonExistentUser_ReturnsUnauthorized()
+    {
+        await _db.CleanDatabaseAsync();
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.PostAsJsonAsync("/api/login",
+            new { username = "nobody_here", password = EndpointTestSupport.Password });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // ----- /api/me -----
+
+    [Fact]
+    public async Task Me_WhenAuthenticated_ReturnsUserInfo()
+    {
+        await _db.CleanDatabaseAsync();
+        var user = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, "me_authed");
+        var client = EndpointTestSupport.NewClient(_factory);
+        await EndpointTestSupport.LoginAsync(client, user.Username);
+
+        var response = await client.GetAsync("/api/me");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(user.Username, body.GetProperty("username").GetString());
+        Assert.False(body.GetProperty("isAdmin").GetBoolean());
+    }
+
+    [Fact]
+    public async Task Me_WhenNotAuthenticated_IsRejected()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.GetAsync("/api/me");
+
+        // Cookie auth challenges an unauthenticated API call with a redirect to the
+        // login page; depending on configuration it may also surface as 401.
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found or HttpStatusCode.Unauthorized,
+            $"Expected redirect or 401 but got {(int)response.StatusCode}.");
+    }
+
+    // ----- /api/logout -----
+
+    [Fact]
+    public async Task Logout_WhenAuthenticated_ReturnsOk()
+    {
+        await _db.CleanDatabaseAsync();
+        var user = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, "logout_ok");
+        var client = EndpointTestSupport.NewClient(_factory);
+        await EndpointTestSupport.LoginAsync(client, user.Username);
+
+        var response = await client.PostAsync("/api/logout", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Logout_ThenMe_IsNoLongerAuthenticated()
+    {
+        await _db.CleanDatabaseAsync();
+        var user = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, "logout_clears");
+        var client = EndpointTestSupport.NewClient(_factory);
+        await EndpointTestSupport.LoginAsync(client, user.Username);
+
+        var before = await client.GetAsync("/api/me");
+        Assert.Equal(HttpStatusCode.OK, before.StatusCode);
+
+        await client.PostAsync("/api/logout", content: null);
+
+        var after = await client.GetAsync("/api/me");
+        Assert.NotEqual(HttpStatusCode.OK, after.StatusCode);
+    }
+}

--- a/HedgehogPanel.Tests/Integration/Endpoints/AuthValidationTests.cs
+++ b/HedgehogPanel.Tests/Integration/Endpoints/AuthValidationTests.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Endpoints;
+
+/// <summary>
+/// Input-validation branches of POST /api/login. These are rejected before any database
+/// or authentication work, so no seeding is required. Uses its own factory instance so the
+/// login rate limit is isolated from other endpoint tests.
+/// </summary>
+[Collection("IntegrationTests")]
+public class AuthValidationTests : IClassFixture<HedgehogWebApplicationFactory>
+{
+    private readonly HedgehogWebApplicationFactory _factory;
+
+    public AuthValidationTests(HedgehogWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Login_WithWhitespaceUsername_ReturnsBadRequest()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.PostAsJsonAsync("/api/login",
+            new { username = "   ", password = EndpointTestSupport.Password });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithInvalidUsernameCharacters_ReturnsBadRequest()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.PostAsJsonAsync("/api/login",
+            new { username = "bad user!", password = EndpointTestSupport.Password });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithTooLongUsername_ReturnsBadRequest()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.PostAsJsonAsync("/api/login",
+            new { username = new string('a', 65), password = EndpointTestSupport.Password });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Login_WithTooLongPassword_ReturnsBadRequest()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.PostAsJsonAsync("/api/login",
+            new { username = "validuser", password = new string('x', 257) });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/HedgehogPanel.Tests/Integration/Endpoints/LoginRateLimitTests.cs
+++ b/HedgehogPanel.Tests/Integration/Endpoints/LoginRateLimitTests.cs
@@ -1,0 +1,50 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Endpoints;
+
+/// <summary>
+/// Verifies the per-IP login rate limit (LoginRateLimit policy, 10 requests / 5 min).
+/// Uses a dedicated factory instance so the rate-limit counter is isolated from other tests.
+/// Distinct usernames are used so the per-account lockout (423) is never triggered and only
+/// the rate limiter (429) can fire.
+/// </summary>
+[Collection("IntegrationTests")]
+public class LoginRateLimitTests : IClassFixture<LoginRateLimitTests.RateLimitFactory>
+{
+    private readonly RateLimitFactory _factory;
+
+    public LoginRateLimitTests(RateLimitFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Login_AfterExceedingLimit_Returns429()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+        var sawTooManyRequests = false;
+
+        for (var i = 0; i < 15; i++)
+        {
+            var response = await client.PostAsJsonAsync("/api/login",
+                new { username = $"ratelimit_user_{i}", password = EndpointTestSupport.Password });
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                sawTooManyRequests = true;
+                break;
+            }
+        }
+
+        Assert.True(sawTooManyRequests, "Expected the login rate limiter to return 429 within 15 attempts.");
+    }
+
+    /// <summary>Dedicated factory so this class has its own rate-limit partition.</summary>
+    public sealed class RateLimitFactory : HedgehogWebApplicationFactory
+    {
+    }
+}

--- a/HedgehogPanel.Tests/Integration/Endpoints/NodeEndpointsTests.cs
+++ b/HedgehogPanel.Tests/Integration/Endpoints/NodeEndpointsTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Endpoints;
+
+/// <summary>End-to-end tests for the node endpoints (/api/nodes CRUD).</summary>
+[Collection("IntegrationTests")]
+public class NodeEndpointsTests : IClassFixture<HedgehogWebApplicationFactory>
+{
+    private readonly PostgreSqlFixture _db;
+    private readonly HedgehogWebApplicationFactory _factory;
+
+    public NodeEndpointsTests(PostgreSqlFixture db, HedgehogWebApplicationFactory factory)
+    {
+        _db = db;
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetNodes_WhenNotAuthenticated_IsRejected()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.GetAsync("/api/nodes");
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found or HttpStatusCode.Unauthorized,
+            $"Expected redirect or 401 but got {(int)response.StatusCode}.");
+    }
+
+    [Fact]
+    public async Task CreateNode_WithValidData_ReturnsOkAndAppearsInList()
+    {
+        var client = await AuthenticatedClientAsync("node_create");
+
+        var create = await client.PostAsJsonAsync("/api/nodes",
+            new { name = "Node-A", ipAddress = "10.0.0.1", port = 50051, description = "first", status = "Online", registrationToken = (string?)null });
+        Assert.Equal(HttpStatusCode.OK, create.StatusCode);
+
+        var list = await client.GetAsync("/api/nodes");
+        Assert.Equal(HttpStatusCode.OK, list.StatusCode);
+        var body = await list.Content.ReadFromJsonAsync<JsonElement>();
+        var names = body.EnumerateArray().Select(e => e.GetProperty("name").GetString()).ToList();
+        Assert.Contains("Node-A", names);
+    }
+
+    [Fact]
+    public async Task CreateNode_WithDuplicateName_ReturnsBadRequest()
+    {
+        var client = await AuthenticatedClientAsync("node_dup");
+
+        await client.PostAsJsonAsync("/api/nodes",
+            new { name = "Node-Dup", ipAddress = "10.0.0.2", port = 50051, description = (string?)null, status = (string?)null, registrationToken = (string?)null });
+
+        var duplicate = await client.PostAsJsonAsync("/api/nodes",
+            new { name = "Node-Dup", ipAddress = "10.0.0.3", port = 50052, description = (string?)null, status = (string?)null, registrationToken = (string?)null });
+
+        Assert.Equal(HttpStatusCode.BadRequest, duplicate.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateNode_WhenExists_ReturnsOk()
+    {
+        var client = await AuthenticatedClientAsync("node_update");
+
+        var create = await client.PostAsJsonAsync("/api/nodes",
+            new { name = "Node-Upd", ipAddress = "10.0.0.4", port = 50051, description = (string?)null, status = (string?)null, registrationToken = (string?)null });
+        var id = (await create.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("id").GetString();
+
+        var update = await client.PutAsJsonAsync($"/api/nodes/{id}",
+            new { name = "Node-Upd-2", ipAddress = "10.0.0.5", port = 50060, description = "changed", status = "Offline", registrationToken = (string?)null });
+
+        Assert.Equal(HttpStatusCode.OK, update.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateNode_WhenNotExists_ReturnsNotFound()
+    {
+        var client = await AuthenticatedClientAsync("node_update_missing");
+
+        var update = await client.PutAsJsonAsync($"/api/nodes/{Guid.NewGuid()}",
+            new { name = "Ghost", ipAddress = "10.0.0.9", port = 50051, description = (string?)null, status = (string?)null, registrationToken = (string?)null });
+
+        Assert.Equal(HttpStatusCode.NotFound, update.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteNode_WhenExists_ReturnsOk()
+    {
+        var client = await AuthenticatedClientAsync("node_delete");
+
+        var create = await client.PostAsJsonAsync("/api/nodes",
+            new { name = "Node-Del", ipAddress = "10.0.0.6", port = 50051, description = (string?)null, status = (string?)null, registrationToken = (string?)null });
+        var id = (await create.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("id").GetString();
+
+        var delete = await client.DeleteAsync($"/api/nodes/{id}");
+
+        Assert.Equal(HttpStatusCode.OK, delete.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteNode_WhenNotExists_ReturnsNotFound()
+    {
+        var client = await AuthenticatedClientAsync("node_delete_missing");
+
+        var delete = await client.DeleteAsync($"/api/nodes/{Guid.NewGuid()}");
+
+        Assert.Equal(HttpStatusCode.NotFound, delete.StatusCode);
+    }
+
+    private async Task<HttpClient> AuthenticatedClientAsync(string prefix)
+    {
+        await _db.CleanDatabaseAsync();
+        var user = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, prefix);
+        var client = EndpointTestSupport.NewClient(_factory);
+        await EndpointTestSupport.LoginAsync(client, user.Username);
+        return client;
+    }
+}

--- a/HedgehogPanel.Tests/Integration/Endpoints/SecurityTests.cs
+++ b/HedgehogPanel.Tests/Integration/Endpoints/SecurityTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Endpoints;
+
+/// <summary>Cross-cutting security tests: CSP headers and JWT bearer authentication.</summary>
+[Collection("IntegrationTests")]
+public class SecurityTests : IClassFixture<HedgehogWebApplicationFactory>
+{
+    private readonly PostgreSqlFixture _db;
+    private readonly HedgehogWebApplicationFactory _factory;
+
+    public SecurityTests(PostgreSqlFixture db, HedgehogWebApplicationFactory factory)
+    {
+        _db = db;
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task Response_IncludesContentSecurityPolicyHeader()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.GetAsync("/html/login.html");
+
+        Assert.True(response.Headers.Contains("Content-Security-Policy"));
+        var csp = string.Join(" ", response.Headers.GetValues("Content-Security-Policy"));
+        Assert.Contains("default-src 'self'", csp);
+    }
+
+    [Fact]
+    public async Task Response_IncludesHardeningHeaders()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.GetAsync("/html/login.html");
+
+        Assert.True(response.Headers.Contains("X-Content-Type-Options"));
+        Assert.True(response.Headers.Contains("X-Frame-Options"));
+    }
+
+    [Fact]
+    public async Task JwtBearerToken_AuthenticatesProtectedEndpoint()
+    {
+        await _db.CleanDatabaseAsync();
+        var user = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, "jwt_user");
+
+        var loginClient = EndpointTestSupport.NewClient(_factory);
+        var login = await loginClient.PostAsJsonAsync("/api/login",
+            new { username = user.Username, password = EndpointTestSupport.Password });
+        login.EnsureSuccessStatusCode();
+        var token = (await login.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("token").GetString();
+        Assert.False(string.IsNullOrEmpty(token));
+
+        // Fresh client without the auth cookie — only the bearer token can authenticate it.
+        var bearerClient = EndpointTestSupport.NewClient(_factory);
+        bearerClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await bearerClient.GetAsync("/api/me");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(user.Username, body.GetProperty("username").GetString());
+    }
+}

--- a/HedgehogPanel.Tests/Integration/Endpoints/ServerEndpointsTests.cs
+++ b/HedgehogPanel.Tests/Integration/Endpoints/ServerEndpointsTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using HedgehogPanel.Infrastructure.Persistence.PostgreSQL.Repositories;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Endpoints;
+
+/// <summary>End-to-end tests for GET /api/servers.</summary>
+[Collection("IntegrationTests")]
+public class ServerEndpointsTests : IClassFixture<HedgehogWebApplicationFactory>
+{
+    private readonly PostgreSqlFixture _db;
+    private readonly HedgehogWebApplicationFactory _factory;
+
+    public ServerEndpointsTests(PostgreSqlFixture db, HedgehogWebApplicationFactory factory)
+    {
+        _db = db;
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetServers_WhenNotAuthenticated_IsRejected()
+    {
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        var response = await client.GetAsync("/api/servers");
+
+        Assert.True(
+            response.StatusCode is HttpStatusCode.Redirect or HttpStatusCode.Found or HttpStatusCode.Unauthorized,
+            $"Expected redirect or 401 but got {(int)response.StatusCode}.");
+    }
+
+    [Fact]
+    public async Task GetServers_ReturnsServersOwnedByUser()
+    {
+        await _db.CleanDatabaseAsync();
+        var user = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, "srv_owner");
+
+        var serverRepository = new ServerRepository(new EndpointTestConnectionFactory(_db.ConnectionString));
+        var server = TestDataBuilder.CreateTestServer("MyServer", "my.hedgehog.batacek.eu");
+        await serverRepository.CreateAsync(server);
+        await serverRepository.AssignToUserAsync(server.Guid, user.Guid);
+
+        var client = EndpointTestSupport.NewClient(_factory);
+        await EndpointTestSupport.LoginAsync(client, user.Username);
+
+        var response = await client.GetAsync("/api/servers");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var names = body.EnumerateArray().Select(e => e.GetProperty("name").GetString()).ToList();
+        Assert.Contains("MyServer", names);
+    }
+
+    [Fact]
+    public async Task GetServers_WhenUserHasNoServers_ReturnsEmptyArray()
+    {
+        await _db.CleanDatabaseAsync();
+        var user = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, "srv_none");
+
+        var client = EndpointTestSupport.NewClient(_factory);
+        await EndpointTestSupport.LoginAsync(client, user.Username);
+
+        var response = await client.GetAsync("/api/servers");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(JsonValueKind.Array, body.ValueKind);
+        Assert.Empty(body.EnumerateArray());
+    }
+}

--- a/HedgehogPanel.Tests/Integration/Repositories/AccountRepositoryTests.cs
+++ b/HedgehogPanel.Tests/Integration/Repositories/AccountRepositoryTests.cs
@@ -1,0 +1,391 @@
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using HedgehogPanel.Application.Persistence;
+using HedgehogPanel.Application.Repositories;
+using HedgehogPanel.Infrastructure.Persistence.PostgreSQL.Repositories;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Npgsql;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Repositories;
+
+[Collection("IntegrationTests")]
+public class AccountRepositoryTests
+{
+    private readonly PostgreSqlFixture _fixture;
+    private readonly IAccountRepository _repository;
+
+    public AccountRepositoryTests(PostgreSqlFixture fixture)
+    {
+        _fixture = fixture;
+        var connectionFactory = new TestConnectionFactory(_fixture.ConnectionString);
+        _repository = new AccountRepository(connectionFactory);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithValidAccount_InsertsAccountWithBcryptHash()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var account = TestDataBuilder.CreateTestAccount("testuser1", "test1@hedgehog.batacek.eu");
+        var password = "securePassword123";
+
+        // Act
+        var result = await _repository.CreateAsync(account, password);
+
+        // Assert
+        Assert.True(result);
+        var retrieved = await _repository.GetByUsernameAsync("testuser1");
+        Assert.NotNull(retrieved);
+        Assert.Equal(account.Guid, retrieved.Guid);
+        Assert.Equal("testuser1", retrieved.Username);
+        Assert.Equal("test1@hedgehog.batacek.eu", retrieved.Email);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithDuplicateUsername_ReturnsFalse()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var account1 = TestDataBuilder.CreateTestAccount("duplicate", "email1@hedgehog.batacek.eu");
+        var account2 = TestDataBuilder.CreateTestAccount("duplicate", "email2@hedgehog.batacek.eu");
+        await _repository.CreateAsync(account1, "pass1");
+
+        // Act & Assert
+        await Assert.ThrowsAnyAsync<Exception>(() => _repository.CreateAsync(account2, "pass2"));
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WithCorrectPassword_ReturnsAccount()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var account = TestDataBuilder.CreateTestAccount("authuser", "auth@hedgehog.batacek.eu");
+        var password = "correctPassword123";
+        await _repository.CreateAsync(account, password);
+
+        // Act
+        var result = await _repository.AuthenticateAsync("authuser", password);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(account.Guid, result.Guid);
+        Assert.Equal("authuser", result.Username);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WithIncorrectPassword_ReturnsNull()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var account = TestDataBuilder.CreateTestAccount("authuser2", "auth2@hedgehog.batacek.eu");
+        await _repository.CreateAsync(account, "correctPassword");
+
+        // Act
+        var result = await _repository.AuthenticateAsync("authuser2", "wrongPassword");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WithNonExistentUser_ReturnsNull()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+
+        // Act
+        var result = await _repository.AuthenticateAsync("nonexistent", "anyPassword");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByUsernameAsync_WhenExists_ReturnsAccount()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var account = TestDataBuilder.CreateTestAccount("getuser", "get@hedgehog.batacek.eu");
+        await _repository.CreateAsync(account, "password");
+
+        // Act
+        var result = await _repository.GetByUsernameAsync("getuser");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(account.Guid, result.Guid);
+        Assert.Equal("getuser", result.Username);
+    }
+
+    [Fact]
+    public async Task GetByUsernameAsync_WhenNotExists_ReturnsNull()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+
+        // Act
+        var result = await _repository.GetByUsernameAsync("nonexistent");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByGuidAsync_WhenExists_ReturnsAccount()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var account = TestDataBuilder.CreateTestAccount("guiduser", "guid@hedgehog.batacek.eu");
+        await _repository.CreateAsync(account, "password");
+
+        // Act
+        var result = await _repository.GetByGuidAsync(account.Guid);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(account.Guid, result.Guid);
+        Assert.Equal("guiduser", result.Username);
+    }
+
+    [Fact]
+    public async Task GetByGuidAsync_WhenNotExists_ReturnsNull()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+
+        // Act
+        var result = await _repository.GetByGuidAsync(Guid.NewGuid());
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithoutPasswordChange_UpdatesAccountDetails()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var account = TestDataBuilder.CreateTestAccount("updateuser", "update@hedgehog.batacek.eu");
+        await _repository.CreateAsync(account, "password");
+        
+        var retrieved = await _repository.GetByUsernameAsync("updateuser");
+        Assert.NotNull(retrieved);
+
+        // Act
+        var updatedAccount = new HedgehogPanel.Domain.Entities.Account(
+            retrieved.Guid, 
+            "updatedusername", 
+            "updated@hedgehog.batacek.eu", 
+            true, 
+            null, 
+            "NewFirst", 
+            "NewMiddle", 
+            "NewLast",
+            retrieved.Groups,
+            retrieved.RowVersion
+        );
+        var result = await _repository.UpdateAsync(updatedAccount, null);
+
+        // Assert
+        Assert.True(result);
+        var updated = await _repository.GetByGuidAsync(retrieved.Guid);
+        Assert.NotNull(updated);
+        Assert.Equal("updatedusername", updated.Username);
+        Assert.Equal("updated@hedgehog.batacek.eu", updated.Email);
+        Assert.Equal("NewFirst", updated.FirstName);
+        Assert.Equal("NewMiddle", updated.MiddleName);
+        Assert.Equal("NewLast", updated.LastName);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithPasswordChange_UpdatesPasswordHash()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var account = TestDataBuilder.CreateTestAccount("passuser", "pass@hedgehog.batacek.eu");
+        var oldPassword = "oldPassword123";
+        var newPassword = "newPassword456";
+        await _repository.CreateAsync(account, oldPassword);
+
+        var retrieved = await _repository.GetByUsernameAsync("passuser");
+        Assert.NotNull(retrieved);
+
+        // Act
+        await _repository.UpdateAsync(retrieved, newPassword);
+
+        // Assert - old password should not work
+        var authOld = await _repository.AuthenticateAsync("passuser", oldPassword);
+        Assert.Null(authOld);
+
+        // Assert - new password should work
+        var authNew = await _repository.AuthenticateAsync("passuser", newPassword);
+        Assert.NotNull(authNew);
+        Assert.Equal(account.Guid, authNew.Guid);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenExists_RemovesAccount()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var account = TestDataBuilder.CreateTestAccount("deleteuser", "delete@hedgehog.batacek.eu");
+        await _repository.CreateAsync(account, "password");
+
+        // Act
+        var result = await _repository.DeleteAsync(account.Guid);
+
+        // Assert
+        Assert.True(result);
+        var retrieved = await _repository.GetByGuidAsync(account.Guid);
+        Assert.Null(retrieved);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenNotExists_ReturnsFalse()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+
+        // Act
+        var result = await _repository.DeleteAsync(Guid.NewGuid());
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsAccountsWithPagination()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        for (int i = 0; i < 5; i++)
+        {
+            var account = TestDataBuilder.CreateTestAccount($"listuser{i}", $"list{i}@hedgehog.batacek.eu");
+            await _repository.CreateAsync(account, "password");
+        }
+
+        // Act
+        var page1 = await _repository.ListAsync(2, 0);
+        var page2 = await _repository.ListAsync(2, 2);
+
+        // Assert
+        Assert.Equal(2, page1.Count);
+        Assert.Equal(2, page2.Count);
+    }
+
+    [Fact]
+    public async Task ListAsync_WithNoAccounts_ReturnsEmptyList()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+
+        // Act
+        var result = await _repository.ListAsync(10, 0);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByUsernameAsync_ForUserInAdminGroup_PopulatesGroupsAndIsAdmin()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var account = TestDataBuilder.CreateTestAccount("groupuser", "groupuser@hedgehog.batacek.eu");
+        await _repository.CreateAsync(account, "password");
+
+        await using (var conn = new NpgsqlConnection(_fixture.ConnectionString))
+        {
+            await conn.OpenAsync();
+            var groupId = Guid.NewGuid();
+            await using (var groupCmd = new NpgsqlCommand(
+                "INSERT INTO groups (uuid, name, description) VALUES (@id, 'admin', 'Administrators')", conn))
+            {
+                groupCmd.Parameters.AddWithValue("id", groupId);
+                await groupCmd.ExecuteNonQueryAsync();
+            }
+            await using (var membershipCmd = new NpgsqlCommand(
+                "INSERT INTO user_groups (user_uuid, group_uuid, priority) VALUES (@u, @g, 100)", conn))
+            {
+                membershipCmd.Parameters.AddWithValue("u", account.Guid);
+                membershipCmd.Parameters.AddWithValue("g", groupId);
+                await membershipCmd.ExecuteNonQueryAsync();
+            }
+        }
+
+        // Act - LoadUserGroupsAsync joins user_groups + groups when fetching the account.
+        var loaded = await _repository.GetByUsernameAsync("groupuser");
+
+        // Assert
+        Assert.NotNull(loaded);
+        Assert.Contains(loaded.Groups, g => g.Name == "admin");
+        Assert.True(loaded.IsAdmin);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithStaleRowVersion_ReturnsFalse()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var account = TestDataBuilder.CreateTestAccount("concurrency", "concurrency@hedgehog.batacek.eu");
+        await _repository.CreateAsync(account, "password");
+
+        var loaded = await _repository.GetByUsernameAsync("concurrency");
+        Assert.NotNull(loaded);
+        Assert.True(loaded.RowVersion > 0);
+
+        // First update succeeds and bumps the row version (xmin) in the database.
+        var first = await _repository.UpdateAsync(loaded, null);
+        Assert.True(first);
+
+        // `loaded` still carries the now-stale row version, so the optimistic
+        // concurrency check (xmin = @v) matches no rows on the second update.
+        var second = await _repository.UpdateAsync(loaded, null);
+        Assert.False(second);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithCurrentRowVersion_ReturnsTrue()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var account = TestDataBuilder.CreateTestAccount("concurrency_ok", "concurrency_ok@hedgehog.batacek.eu");
+        await _repository.CreateAsync(account, "password");
+
+        var loaded = await _repository.GetByUsernameAsync("concurrency_ok");
+        Assert.NotNull(loaded);
+
+        // Act - updating with the freshly-loaded row version succeeds.
+        var result = await _repository.UpdateAsync(loaded, null);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    private class TestConnectionFactory : IDbConnectionFactory
+    {
+        private readonly string _connectionString;
+
+        public TestConnectionFactory(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public IDbConnection CreateConnection()
+        {
+            var connection = new NpgsqlConnection(_connectionString);
+            connection.Open();
+            return connection;
+        }
+
+        public async ValueTask<IDbConnection> CreateConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            var connection = new NpgsqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            return connection;
+        }
+    }
+}

--- a/HedgehogPanel.Tests/Integration/Repositories/NodeRepositoryTests.cs
+++ b/HedgehogPanel.Tests/Integration/Repositories/NodeRepositoryTests.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using HedgehogPanel.Application.Contracts.Logging;
+using HedgehogPanel.Application.Persistence;
+using HedgehogPanel.Application.Repositories;
+using HedgehogPanel.Infrastructure.Configuration;
+using HedgehogPanel.Infrastructure.Persistence.PostgreSQL.Repositories;
+using HedgehogPanel.Infrastructure.Persistence.Store;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Moq;
+using Npgsql;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Repositories;
+
+[Collection("IntegrationTests")]
+public class NodeRepositoryTests
+{
+    private readonly PostgreSqlFixture _fixture;
+    private readonly INodeRepository _repository;
+
+    public NodeRepositoryTests(PostgreSqlFixture fixture)
+    {
+        _fixture = fixture;
+        var connectionFactory = new TestConnectionFactory(_fixture.ConnectionString);
+        var config = new HedgehogConfig { Cache = new CacheConfig { Enabled = false } };
+        var mockLogger = new Mock<ILoggerService>();
+        var store = new InMemoryStore(mockLogger.Object, config);
+        _repository = new NodeRepository(connectionFactory, store, config);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithValidNode_InsertsNode()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var node = TestDataBuilder.CreateTestNode("TestNode1", "192.168.1.100", 50051);
+
+        // Act
+        var result = await _repository.CreateAsync(node);
+
+        // Assert
+        Assert.True(result);
+        var retrieved = await _repository.GetByGuidAsync(node.Guid);
+        Assert.NotNull(retrieved);
+        Assert.Equal(node.Guid, retrieved.Guid);
+        Assert.Equal("TestNode1", retrieved.Name);
+        Assert.Equal("192.168.1.100", retrieved.IpAddress);
+        Assert.Equal(50051, retrieved.Port);
+    }
+
+    [Fact]
+    public async Task GetByGuidAsync_WhenExists_ReturnsNode()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var node = TestDataBuilder.CreateTestNode("GetNode", "10.0.0.1", 50051);
+        await _repository.CreateAsync(node);
+
+        // Act
+        var result = await _repository.GetByGuidAsync(node.Guid);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(node.Guid, result.Guid);
+        Assert.Equal("GetNode", result.Name);
+        Assert.Equal("10.0.0.1", result.IpAddress);
+    }
+
+    [Fact]
+    public async Task GetByGuidAsync_WhenNotExists_ReturnsNull()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+
+        // Act
+        var result = await _repository.GetByGuidAsync(Guid.NewGuid());
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsNodesWithPagination()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        for (int i = 0; i < 5; i++)
+        {
+            var node = TestDataBuilder.CreateTestNode($"Node{i}", $"192.168.1.{i}", 50051);
+            await _repository.CreateAsync(node);
+        }
+
+        // Act
+        var page1 = await _repository.ListAsync(2, 0);
+        var page2 = await _repository.ListAsync(2, 2);
+
+        // Assert
+        Assert.Equal(2, page1.Count);
+        Assert.Equal(2, page2.Count);
+    }
+
+    [Fact]
+    public async Task ListAsync_WithNoNodes_ReturnsEmptyList()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+
+        // Act
+        var result = await _repository.ListAsync(10, 0);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_UpdatesNodeDetails()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var node = TestDataBuilder.CreateTestNode("OriginalNode", "192.168.1.1", 50051);
+        await _repository.CreateAsync(node);
+
+        // Act
+        var updatedNode = new HedgehogPanel.Domain.Entities.Node(
+            node.Guid,
+            "UpdatedNode",
+            "192.168.1.200",
+            50052,
+            "Updated description",
+            "Online"
+        );
+        var result = await _repository.UpdateAsync(updatedNode);
+
+        // Assert
+        Assert.True(result);
+        var retrieved = await _repository.GetByGuidAsync(node.Guid);
+        Assert.NotNull(retrieved);
+        Assert.Equal("UpdatedNode", retrieved.Name);
+        Assert.Equal("192.168.1.200", retrieved.IpAddress);
+        Assert.Equal(50052, retrieved.Port);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenNotExists_ReturnsFalse()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var node = TestDataBuilder.CreateTestNode();
+
+        // Act
+        var result = await _repository.UpdateAsync(node);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenExists_RemovesNode()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var node = TestDataBuilder.CreateTestNode("DeleteNode", "192.168.1.50", 50051);
+        await _repository.CreateAsync(node);
+
+        // Act
+        var result = await _repository.DeleteAsync(node.Guid);
+
+        // Assert
+        Assert.True(result);
+        var retrieved = await _repository.GetByGuidAsync(node.Guid);
+        Assert.Null(retrieved);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenNotExists_ReturnsFalse()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+
+        // Act
+        var result = await _repository.DeleteAsync(Guid.NewGuid());
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithDuplicateName_ThrowsException()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var node1 = TestDataBuilder.CreateTestNode("DuplicateNode", "192.168.1.1", 50051);
+        var node2 = TestDataBuilder.CreateTestNode("DuplicateNode", "192.168.1.2", 50052);
+        await _repository.CreateAsync(node1);
+
+        // Act & Assert
+        await Assert.ThrowsAnyAsync<Exception>(() => _repository.CreateAsync(node2));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RenamingToAnotherNodesName_ThrowsException()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var nodeA = TestDataBuilder.CreateTestNode("Node-X", "192.168.1.1", 50051);
+        var nodeB = TestDataBuilder.CreateTestNode("Node-Y", "192.168.1.2", 50052);
+        await _repository.CreateAsync(nodeA);
+        await _repository.CreateAsync(nodeB);
+
+        // Act & Assert - renaming B to A's name must be rejected by the duplicate-name guard.
+        var renamed = new HedgehogPanel.Domain.Entities.Node(nodeB.Guid, "Node-X", "192.168.1.2", 50052);
+        await Assert.ThrowsAnyAsync<Exception>(() => _repository.UpdateAsync(renamed));
+    }
+
+    [Fact]
+    public async Task ListAsync_OrdersByCreatedAt()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var node1 = TestDataBuilder.CreateTestNode("Node1", "192.168.1.1", 50051);
+        var node2 = TestDataBuilder.CreateTestNode("Node2", "192.168.1.2", 50051);
+        var node3 = TestDataBuilder.CreateTestNode("Node3", "192.168.1.3", 50051);
+        
+        await _repository.CreateAsync(node1);
+        await Task.Delay(10); // Ensure different timestamps
+        await _repository.CreateAsync(node2);
+        await Task.Delay(10);
+        await _repository.CreateAsync(node3);
+
+        // Act
+        var result = await _repository.ListAsync(10, 0);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        // Nodes should be ordered (implementation dependent - typically by created_at)
+    }
+
+    private class TestConnectionFactory : IDbConnectionFactory
+    {
+        private readonly string _connectionString;
+
+        public TestConnectionFactory(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public IDbConnection CreateConnection()
+        {
+            var connection = new NpgsqlConnection(_connectionString);
+            connection.Open();
+            return connection;
+        }
+
+        public async ValueTask<IDbConnection> CreateConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            var connection = new NpgsqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            return connection;
+        }
+    }
+}

--- a/HedgehogPanel.Tests/Integration/Repositories/ServerRepositoryTests.cs
+++ b/HedgehogPanel.Tests/Integration/Repositories/ServerRepositoryTests.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HedgehogPanel.Application.Persistence;
+using HedgehogPanel.Application.Repositories;
+using HedgehogPanel.Infrastructure.Persistence.PostgreSQL.Repositories;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Npgsql;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Repositories;
+
+[Collection("IntegrationTests")]
+public class ServerRepositoryTests
+{
+    private readonly PostgreSqlFixture _fixture;
+    private readonly IServerRepository _serverRepository;
+    private readonly IAccountRepository _accountRepository;
+
+    public ServerRepositoryTests(PostgreSqlFixture fixture)
+    {
+        _fixture = fixture;
+        var connectionFactory = new TestConnectionFactory(_fixture.ConnectionString);
+        _serverRepository = new ServerRepository(connectionFactory);
+        _accountRepository = new AccountRepository(connectionFactory);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithValidServer_InsertsServer()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var server = TestDataBuilder.CreateTestServer("TestServer1", "server1.hedgehog.batacek.eu", 22);
+
+        // Act
+        var result = await _serverRepository.CreateAsync(server);
+
+        // Assert
+        Assert.True(result);
+        var retrieved = await _serverRepository.GetByGuidAsync(server.Guid);
+        Assert.NotNull(retrieved);
+        Assert.Equal(server.Guid, retrieved.Guid);
+        Assert.Equal("TestServer1", retrieved.Name);
+        Assert.Equal("server1.hedgehog.batacek.eu", retrieved.Hostname);
+        Assert.Equal(22, retrieved.DaemonPort);
+    }
+
+    [Fact]
+    public async Task GetByGuidAsync_WhenExists_ReturnsServer()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var server = TestDataBuilder.CreateTestServer("GetServer", "get.hedgehog.batacek.eu");
+        await _serverRepository.CreateAsync(server);
+
+        // Act
+        var result = await _serverRepository.GetByGuidAsync(server.Guid);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(server.Guid, result.Guid);
+        Assert.Equal("GetServer", result.Name);
+    }
+
+    [Fact]
+    public async Task GetByGuidAsync_WhenNotExists_ReturnsNull()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+
+        // Act
+        var result = await _serverRepository.GetByGuidAsync(Guid.NewGuid());
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsServersWithPagination()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        for (int i = 0; i < 5; i++)
+        {
+            var server = TestDataBuilder.CreateTestServer($"Server{i}", $"server{i}.hedgehog.batacek.eu");
+            await _serverRepository.CreateAsync(server);
+        }
+
+        // Act
+        var page1 = await _serverRepository.ListAsync(2, 0);
+        var page2 = await _serverRepository.ListAsync(2, 2);
+
+        // Assert
+        Assert.Equal(2, page1.Count);
+        Assert.Equal(2, page2.Count);
+    }
+
+    [Fact]
+    public async Task ListAsync_WithNoServers_ReturnsEmptyList()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+
+        // Act
+        var result = await _serverRepository.ListAsync(10, 0);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_UpdatesServerDetails()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var server = TestDataBuilder.CreateTestServer("OriginalName", "original.hedgehog.batacek.eu", 22);
+        await _serverRepository.CreateAsync(server);
+
+        // Act
+        var updatedServer = new HedgehogPanel.Domain.Entities.Server(
+            server.Guid,
+            "UpdatedName",
+            "updated.hedgehog.batacek.eu",
+            2222,
+            HedgehogPanel.Domain.Enums.ServerStatus.Online,
+            null,
+            "Updated description"
+        );
+        var result = await _serverRepository.UpdateAsync(updatedServer);
+
+        // Assert
+        Assert.True(result);
+        var retrieved = await _serverRepository.GetByGuidAsync(server.Guid);
+        Assert.NotNull(retrieved);
+        Assert.Equal("UpdatedName", retrieved.Name);
+        Assert.Equal("updated.hedgehog.batacek.eu", retrieved.Hostname);
+        Assert.Equal(2222, retrieved.DaemonPort);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenNotExists_ReturnsFalse()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var server = TestDataBuilder.CreateTestServer();
+
+        // Act
+        var result = await _serverRepository.UpdateAsync(server);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenExists_RemovesServer()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var server = TestDataBuilder.CreateTestServer("DeleteServer", "delete.hedgehog.batacek.eu");
+        await _serverRepository.CreateAsync(server);
+
+        // Act
+        var result = await _serverRepository.DeleteAsync(server.Guid);
+
+        // Assert
+        Assert.True(result);
+        var retrieved = await _serverRepository.GetByGuidAsync(server.Guid);
+        Assert.Null(retrieved);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenNotExists_ReturnsFalse()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+
+        // Act
+        var result = await _serverRepository.DeleteAsync(Guid.NewGuid());
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ListByOwnerAsync_ReturnsOnlyOwnedServers()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var user = TestDataBuilder.CreateTestAccount("owner1", "owner1@hedgehog.batacek.eu");
+        await _accountRepository.CreateAsync(user, "password");
+
+        var server1 = TestDataBuilder.CreateTestServer("OwnedServer1", "owned1.hedgehog.batacek.eu");
+        var server2 = TestDataBuilder.CreateTestServer("OwnedServer2", "owned2.hedgehog.batacek.eu");
+        var server3 = TestDataBuilder.CreateTestServer("UnownedServer", "unowned.hedgehog.batacek.eu");
+        
+        await _serverRepository.CreateAsync(server1);
+        await _serverRepository.CreateAsync(server2);
+        await _serverRepository.CreateAsync(server3);
+
+        await _serverRepository.AssignToUserAsync(server1.Guid, user.Guid);
+        await _serverRepository.AssignToUserAsync(server2.Guid, user.Guid);
+
+        // Act
+        var result = await _serverRepository.ListByOwnerAsync(user.Guid);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, s => s.Guid == server1.Guid);
+        Assert.Contains(result, s => s.Guid == server2.Guid);
+        Assert.DoesNotContain(result, s => s.Guid == server3.Guid);
+    }
+
+    [Fact]
+    public async Task ListByOwnerAsync_WithNoOwnedServers_ReturnsEmptyList()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var user = TestDataBuilder.CreateTestAccount("owner2", "owner2@hedgehog.batacek.eu");
+        await _accountRepository.CreateAsync(user, "password");
+
+        // Act
+        var result = await _serverRepository.ListByOwnerAsync(user.Guid);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ListUnownedAsync_ReturnsOnlyUnownedServers()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var user = TestDataBuilder.CreateTestAccount("owner3", "owner3@hedgehog.batacek.eu");
+        await _accountRepository.CreateAsync(user, "password");
+
+        var ownedServer = TestDataBuilder.CreateTestServer("Owned", "owned.hedgehog.batacek.eu");
+        var unownedServer1 = TestDataBuilder.CreateTestServer("Unowned1", "unowned1.hedgehog.batacek.eu");
+        var unownedServer2 = TestDataBuilder.CreateTestServer("Unowned2", "unowned2.hedgehog.batacek.eu");
+
+        await _serverRepository.CreateAsync(ownedServer);
+        await _serverRepository.CreateAsync(unownedServer1);
+        await _serverRepository.CreateAsync(unownedServer2);
+
+        await _serverRepository.AssignToUserAsync(ownedServer.Guid, user.Guid);
+
+        // Act
+        var result = await _serverRepository.ListUnownedAsync();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, s => s.Guid == unownedServer1.Guid);
+        Assert.Contains(result, s => s.Guid == unownedServer2.Guid);
+        Assert.DoesNotContain(result, s => s.Guid == ownedServer.Guid);
+    }
+
+    [Fact]
+    public async Task GetOwnerUsernameAsync_WhenServerHasOwner_ReturnsUsername()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var user = TestDataBuilder.CreateTestAccount("serverowner", "serverowner@hedgehog.batacek.eu");
+        await _accountRepository.CreateAsync(user, "password");
+
+        var server = TestDataBuilder.CreateTestServer("OwnedServer", "owned.hedgehog.batacek.eu");
+        await _serverRepository.CreateAsync(server);
+        await _serverRepository.AssignToUserAsync(server.Guid, user.Guid);
+
+        // Act
+        var result = await _serverRepository.GetOwnerUsernameAsync(server.Guid);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("serverowner", result);
+    }
+
+    [Fact]
+    public async Task GetOwnerUsernameAsync_WhenServerHasNoOwner_ReturnsNull()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var server = TestDataBuilder.CreateTestServer("NoOwner", "noowner.hedgehog.batacek.eu");
+        await _serverRepository.CreateAsync(server);
+
+        // Act
+        var result = await _serverRepository.GetOwnerUsernameAsync(server.Guid);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task AssignToUserAsync_AssignsServerToUser()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var user = TestDataBuilder.CreateTestAccount("assignuser", "assign@hedgehog.batacek.eu");
+        await _accountRepository.CreateAsync(user, "password");
+
+        var server = TestDataBuilder.CreateTestServer("AssignServer", "assign.hedgehog.batacek.eu");
+        await _serverRepository.CreateAsync(server);
+
+        // Act
+        var result = await _serverRepository.AssignToUserAsync(server.Guid, user.Guid);
+
+        // Assert
+        Assert.True(result);
+        var ownerUsername = await _serverRepository.GetOwnerUsernameAsync(server.Guid);
+        Assert.Equal("assignuser", ownerUsername);
+    }
+
+    [Fact]
+    public async Task AssignToUserAsync_WhenServerNotExists_ReturnsFalse()
+    {
+        // Arrange
+        await _fixture.CleanDatabaseAsync();
+        var user = TestDataBuilder.CreateTestAccount("user", "user@hedgehog.batacek.eu");
+        await _accountRepository.CreateAsync(user, "password");
+
+        // Act
+        var result = await _serverRepository.AssignToUserAsync(Guid.NewGuid(), user.Guid);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    private class TestConnectionFactory : IDbConnectionFactory
+    {
+        private readonly string _connectionString;
+
+        public TestConnectionFactory(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        public IDbConnection CreateConnection()
+        {
+            var connection = new NpgsqlConnection(_connectionString);
+            connection.Open();
+            return connection;
+        }
+
+        public async ValueTask<IDbConnection> CreateConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            var connection = new NpgsqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            return connection;
+        }
+    }
+}

--- a/HedgehogPanel.Tests/Integration/TestFixtures/EndpointTestSupport.cs
+++ b/HedgehogPanel.Tests/Integration/TestFixtures/EndpointTestSupport.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Data;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using HedgehogPanel;
+using HedgehogPanel.Application.Persistence;
+using HedgehogPanel.Domain.Entities;
+using HedgehogPanel.Infrastructure.Persistence.PostgreSQL.Repositories;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Npgsql;
+
+namespace HedgehogPanel.Tests.Integration.TestFixtures;
+
+/// <summary>Shared helpers for the endpoint integration tests: client creation,
+/// user/admin seeding and login.</summary>
+public static class EndpointTestSupport
+{
+    public const string Password = "Test_Password_123";
+
+    /// <summary>Creates a client that does not auto-follow redirects, so status codes
+    /// (e.g. the auth challenge redirect) can be asserted directly.</summary>
+    public static HttpClient NewClient(WebApplicationFactory<Program> factory) =>
+        factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+    /// <summary>Inserts a fresh active user (unique username derived from <paramref name="prefix"/>).</summary>
+    public static async Task<Account> SeedUserAsync(string connectionString, string prefix)
+    {
+        var username = Unique(prefix);
+        var account = new Account(Guid.NewGuid(), username, $"{username}@hedgehog.batacek.eu");
+        var repository = new AccountRepository(new EndpointTestConnectionFactory(connectionString));
+        await repository.CreateAsync(account, Password);
+        return account;
+    }
+
+    /// <summary>Inserts a fresh user and puts it into the "admin" group so it gains the Admin role.</summary>
+    public static async Task<Account> SeedAdminAsync(string connectionString, string prefix)
+    {
+        var account = await SeedUserAsync(connectionString, prefix);
+
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync();
+
+        var groupId = Guid.NewGuid();
+        await using (var groupCmd = new NpgsqlCommand(
+            "INSERT INTO groups (uuid, name, description) VALUES (@id, 'admin', 'Administrators')", conn))
+        {
+            groupCmd.Parameters.AddWithValue("id", groupId);
+            await groupCmd.ExecuteNonQueryAsync();
+        }
+
+        await using (var membershipCmd = new NpgsqlCommand(
+            "INSERT INTO user_groups (user_uuid, group_uuid, priority) VALUES (@u, @g, 100)", conn))
+        {
+            membershipCmd.Parameters.AddWithValue("u", account.Guid);
+            membershipCmd.Parameters.AddWithValue("g", groupId);
+            await membershipCmd.ExecuteNonQueryAsync();
+        }
+
+        return account;
+    }
+
+    /// <summary>Logs the client in with the seeded password; throws if login does not succeed.</summary>
+    public static async Task LoginAsync(HttpClient client, string username)
+    {
+        var response = await client.PostAsJsonAsync("/api/login", new { username, password = Password });
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            throw new Xunit.Sdk.XunitException($"Login failed ({(int)response.StatusCode}): {body}");
+        }
+    }
+
+    private static string Unique(string prefix)
+    {
+        var value = $"{prefix}_{Guid.NewGuid():N}";
+        return value.Length <= 60 ? value : value.Substring(0, 60);
+    }
+}
+
+/// <summary>Opens a real connection to the test database for seeding.</summary>
+public sealed class EndpointTestConnectionFactory : IDbConnectionFactory
+{
+    private readonly string _connectionString;
+
+    public EndpointTestConnectionFactory(string connectionString) => _connectionString = connectionString;
+
+    public IDbConnection CreateConnection()
+    {
+        var connection = new NpgsqlConnection(_connectionString);
+        connection.Open();
+        return connection;
+    }
+
+    public async ValueTask<IDbConnection> CreateConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        var connection = new NpgsqlConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken);
+        return connection;
+    }
+}

--- a/HedgehogPanel.Tests/Integration/TestFixtures/HedgehogWebApplicationFactory.cs
+++ b/HedgehogPanel.Tests/Integration/TestFixtures/HedgehogWebApplicationFactory.cs
@@ -21,13 +21,14 @@ public class HedgehogWebApplicationFactory : WebApplicationFactory<Program>
 {
     static HedgehogWebApplicationFactory()
     {
+        // Database credentials and the JWT secret are taken from the project's .env file; the
         Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
-        Environment.SetEnvironmentVariable("DB_HOST", "localhost");
-        Environment.SetEnvironmentVariable("DB_PORT", "5432");
-        Environment.SetEnvironmentVariable("DB_USER", "postgres");
-        Environment.SetEnvironmentVariable("DB_PASSWORD", "123456Ab");
-        Environment.SetEnvironmentVariable("DB_NAME", "hedgehogdb_test");
-        Environment.SetEnvironmentVariable("JWT_SECRET", "test-jwt-secret-key-for-integration-tests-0123456789");
+        Environment.SetEnvironmentVariable("DB_HOST", TestDatabaseConfig.Host);
+        Environment.SetEnvironmentVariable("DB_PORT", TestDatabaseConfig.Port.ToString());
+        Environment.SetEnvironmentVariable("DB_USER", TestDatabaseConfig.Username);
+        Environment.SetEnvironmentVariable("DB_PASSWORD", TestDatabaseConfig.Password);
+        Environment.SetEnvironmentVariable("DB_NAME", TestDatabaseConfig.Database);
+        Environment.SetEnvironmentVariable("JWT_SECRET", TestDatabaseConfig.JwtSecret);
     }
 
     /// <summary>When true, antiforgery validation is replaced with a no-op so POST/PUT/DELETE

--- a/HedgehogPanel.Tests/Integration/TestFixtures/HedgehogWebApplicationFactory.cs
+++ b/HedgehogPanel.Tests/Integration/TestFixtures/HedgehogWebApplicationFactory.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using HedgehogPanel;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace HedgehogPanel.Tests.Integration.TestFixtures;
+
+/// <summary>
+/// Boots the real application in-memory against the test PostgreSQL database.
+/// Database/JWT settings and the Development environment are exported as environment
+/// variables in the static constructor — before the host is built — because
+/// <c>ConfigLoader</c> reads them directly during startup and the cookie security
+/// policy depends on the environment being Development (so cookies work over HTTP).
+/// </summary>
+public class HedgehogWebApplicationFactory : WebApplicationFactory<Program>
+{
+    static HedgehogWebApplicationFactory()
+    {
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+        Environment.SetEnvironmentVariable("DB_HOST", "localhost");
+        Environment.SetEnvironmentVariable("DB_PORT", "5432");
+        Environment.SetEnvironmentVariable("DB_USER", "postgres");
+        Environment.SetEnvironmentVariable("DB_PASSWORD", "123456Ab");
+        Environment.SetEnvironmentVariable("DB_NAME", "hedgehogdb_test");
+        Environment.SetEnvironmentVariable("JWT_SECRET", "test-jwt-secret-key-for-integration-tests-0123456789");
+    }
+
+    /// <summary>When true, antiforgery validation is replaced with a no-op so POST/PUT/DELETE
+    /// endpoints can be exercised directly without juggling CSRF tokens.</summary>
+    protected virtual bool DisableAntiforgery => true;
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Development");
+        if (DisableAntiforgery)
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.AddSingleton<IAntiforgery, NoOpAntiforgery>();
+            });
+        }
+    }
+
+    /// <summary>No-op antiforgery so state-changing requests skip CSRF validation in tests.</summary>
+    private sealed class NoOpAntiforgery : IAntiforgery
+    {
+        private static AntiforgeryTokenSet Tokens =>
+            new("test-request-token", "test-cookie-token", "__RequestVerificationToken", "X-CSRF-Token");
+
+        public AntiforgeryTokenSet GetAndStoreTokens(HttpContext httpContext) => Tokens;
+        public AntiforgeryTokenSet GetTokens(HttpContext httpContext) => Tokens;
+        public Task<bool> IsRequestValidAsync(HttpContext httpContext) => Task.FromResult(true);
+        public Task ValidateRequestAsync(HttpContext httpContext) => Task.CompletedTask;
+        public void SetCookieTokenAndHeader(HttpContext httpContext) { }
+    }
+}
+
+/// <summary>
+/// Variant of the factory that keeps the real antiforgery middleware active,
+/// used to verify that CSRF protection rejects unprotected state-changing requests.
+/// </summary>
+public class AntiforgeryEnabledWebApplicationFactory : HedgehogWebApplicationFactory
+{
+    protected override bool DisableAntiforgery => false;
+}

--- a/HedgehogPanel.Tests/Integration/TestFixtures/IntegrationTestsCollection.cs
+++ b/HedgehogPanel.Tests/Integration/TestFixtures/IntegrationTestsCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.TestFixtures;
+
+[CollectionDefinition("IntegrationTests")]
+public class IntegrationTestsCollection : ICollectionFixture<PostgreSqlFixture>
+{
+}

--- a/HedgehogPanel.Tests/Integration/TestFixtures/PostgreSqlFixture.cs
+++ b/HedgehogPanel.Tests/Integration/TestFixtures/PostgreSqlFixture.cs
@@ -1,0 +1,130 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Npgsql;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.TestFixtures;
+
+public class PostgreSqlFixture : IAsyncLifetime
+{
+    public string ConnectionString { get; private set; } = string.Empty;
+
+    public PostgreSqlFixture()
+    {
+        // Connection settings come from the project's .env file (database name is suffixed
+        // with _test so the production database is never touched). See TestDatabaseConfig.
+        ConnectionString = TestDatabaseConfig.ConnectionString;
+    }
+
+    public async Task InitializeAsync()
+    {
+        var testDbName = TestDatabaseConfig.Database;
+
+        // Create test database if it doesn't exist
+        try
+        {
+            await using var masterConnection = new NpgsqlConnection(TestDatabaseConfig.MasterConnectionString);
+            await masterConnection.OpenAsync();
+
+            // Check if test database exists
+            await using var checkCmd = new NpgsqlCommand("SELECT 1 FROM pg_database WHERE datname = @name", masterConnection);
+            checkCmd.Parameters.AddWithValue("name", testDbName);
+            var exists = await checkCmd.ExecuteScalarAsync();
+
+            if (exists == null)
+            {
+                // Create test database (identifier is validated in TestDatabaseConfig).
+                await using var createCmd = new NpgsqlCommand($"CREATE DATABASE \"{testDbName}\"", masterConnection);
+                await createCmd.ExecuteNonQueryAsync();
+            }
+        }
+        catch (Npgsql.PostgresException ex) when (ex.SqlState == "23505")
+        {
+            // Database already exists (race condition), ignore
+        }
+
+        // Always ensure schema is applied (check if users table exists)
+        await using var testConnection = new NpgsqlConnection(ConnectionString);
+        await testConnection.OpenAsync();
+        await using var tableCheckCmd = new NpgsqlCommand(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'users'",
+            testConnection);
+        var tableCount = (long)(await tableCheckCmd.ExecuteScalarAsync() ?? 0L);
+        if (tableCount == 0)
+        {
+            await ApplySchemaAsync();
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        // Keep test database for reuse
+        return Task.CompletedTask;
+    }
+
+    private async Task ApplySchemaAsync()
+    {
+        var projectRoot = FindProjectRoot();
+        var sqlPath = Path.Combine(projectRoot, "create.sql");
+        
+        if (!File.Exists(sqlPath))
+        {
+            throw new FileNotFoundException($"SQL schema file not found at: {sqlPath}");
+        }
+
+        var sql = await File.ReadAllTextAsync(sqlPath);
+        
+        // Remove CREATE EXTENSION line to avoid duplicate key error if extension already exists
+        var lines = sql.Split('\n');
+        var filteredLines = System.Linq.Enumerable.Where(lines, l => !l.TrimStart().StartsWith("CREATE EXTENSION"));
+        sql = string.Join('\n', filteredLines);
+
+        await using var connection = new NpgsqlConnection(ConnectionString);
+        await connection.OpenAsync();
+        
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static string FindProjectRoot()
+    {
+        var directory = Directory.GetCurrentDirectory();
+        
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory, "HedgehogPanel.sln")))
+            {
+                return directory;
+            }
+            directory = Directory.GetParent(directory)?.FullName;
+        }
+        
+        throw new InvalidOperationException("Could not find project root (HedgehogPanel.sln)");
+    }
+
+    public async Task CleanDatabaseAsync()
+    {
+        await using var connection = new NpgsqlConnection(ConnectionString);
+        await connection.OpenAsync();
+
+        var tables = new[]
+        {
+            "service_owners", "server_owners", "services", "servers", 
+            "nodes", "user_groups", "groups", "users", "user_security_events"
+        };
+
+        foreach (var table in tables)
+        {
+            var checkSql = "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = @table";
+            await using var checkCmd = new NpgsqlCommand(checkSql, connection);
+            checkCmd.Parameters.AddWithValue("table", table);
+            var count = (long)(await checkCmd.ExecuteScalarAsync() ?? 0L);
+            if (count > 0)
+            {
+                await using var command = new NpgsqlCommand($"TRUNCATE TABLE {table} CASCADE", connection);
+                await command.ExecuteNonQueryAsync();
+            }
+        }
+    }
+}

--- a/HedgehogPanel.Tests/Integration/TestFixtures/TestDataBuilder.cs
+++ b/HedgehogPanel.Tests/Integration/TestFixtures/TestDataBuilder.cs
@@ -1,0 +1,62 @@
+using System;
+using HedgehogPanel.Domain.Entities;
+using HedgehogPanel.Domain.Enums;
+
+namespace HedgehogPanel.Tests.Integration.TestFixtures;
+
+public static class TestDataBuilder
+{
+    public static Account CreateTestAccount(
+        string? username = null,
+        string? email = null,
+        bool isActive = true,
+        Guid? guid = null)
+    {
+        return new Account(
+            guid ?? Guid.NewGuid(),
+            username ?? $"testuser_{Guid.NewGuid():N}",
+            email ?? $"test_{Guid.NewGuid():N}@hedgehog.batacek.eu",
+            isActive
+        );
+    }
+
+    public static Server CreateTestServer(
+        string? name = null,
+        string? hostname = null,
+        int port = 22,
+        Guid? guid = null)
+    {
+        return new Server(
+            guid ?? Guid.NewGuid(),
+            name ?? $"TestServer_{Guid.NewGuid():N}",
+            hostname ?? "test.hedgehog.batacek.eu",
+            port
+        );
+    }
+
+    public static Node CreateTestNode(
+        string? name = null,
+        string? ipAddress = null,
+        int port = 50051,
+        Guid? guid = null)
+    {
+        return new Node(
+            guid ?? Guid.NewGuid(),
+            name ?? $"TestNode_{Guid.NewGuid():N}",
+            ipAddress ?? "127.0.0.1",
+            port
+        );
+    }
+
+    public static Group CreateTestGroup(
+        string? name = null,
+        string? description = null,
+        Guid? guid = null)
+    {
+        return new Group(
+            guid ?? Guid.NewGuid(),
+            name ?? $"TestGroup_{Guid.NewGuid():N}",
+            description
+        );
+    }
+}

--- a/HedgehogPanel.Tests/Integration/TestFixtures/TestDatabaseConfig.cs
+++ b/HedgehogPanel.Tests/Integration/TestFixtures/TestDatabaseConfig.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace HedgehogPanel.Tests.Integration.TestFixtures;
+
+/// <summary>
+/// Resolves the database connection settings for the test run from the project's <c>.env</c>
+/// file (the same file the application uses). Host, port, user, password and the JWT secret are
+/// taken verbatim from <c>.env</c>; the database NAME is intentionally suffixed with
+/// <c>_test</c> so the destructive fixture operations (TRUNCATE, schema reset) can never touch
+/// the production database. Values fall back to sensible defaults if <c>.env</c> is missing.
+/// </summary>
+public static class TestDatabaseConfig
+{
+    public static string Host { get; }
+    public static int Port { get; }
+    public static string Username { get; }
+    public static string Password { get; }
+    public static string Database { get; }
+    public static string JwtSecret { get; }
+
+    public static string ConnectionString =>
+        $"Host={Host};Port={Port};Username={Username};Password={Password};Database={Database}";
+
+    /// <summary>Connection to the server's default <c>postgres</c> database (used to create the test DB).</summary>
+    public static string MasterConnectionString =>
+        $"Host={Host};Port={Port};Username={Username};Password={Password};Database=postgres";
+
+    static TestDatabaseConfig()
+    {
+        var env = LoadDotEnv();
+
+        Host = Value(env, "DB_HOST", "localhost");
+        Port = int.TryParse(Value(env, "DB_PORT", "5432"), out var port) ? port : 5432;
+        Username = Value(env, "DB_USER", "postgres");
+        Password = Value(env, "DB_PASSWORD", "");
+        JwtSecret = Value(env, "JWT_SECRET", "test-jwt-secret-key-for-integration-tests-0123456789");
+
+        var name = Value(env, "DB_NAME", "hedgehogdb");
+        Database = name.EndsWith("_test", StringComparison.OrdinalIgnoreCase) ? name : name + "_test";
+
+        // The database name is interpolated into DDL (CREATE DATABASE), so guard against anything
+        // that is not a plain identifier.
+        if (!Regex.IsMatch(Database, "^[A-Za-z0-9_]+$"))
+            throw new InvalidOperationException($"Resolved test database name '{Database}' is not a valid identifier.");
+    }
+
+    private static string Value(IReadOnlyDictionary<string, string> env, string key, string fallback)
+        => env.TryGetValue(key, out var v) && !string.IsNullOrWhiteSpace(v) ? v : fallback;
+
+    private static Dictionary<string, string> LoadDotEnv()
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var path = FindEnvFile();
+        if (path == null) return result;
+
+        foreach (var raw in File.ReadAllLines(path))
+        {
+            var line = raw.Trim();
+            if (line.Length == 0 || line.StartsWith("#")) continue;
+
+            var idx = line.IndexOf('=');
+            if (idx <= 0) continue;
+
+            var key = line.Substring(0, idx).Trim();
+            var value = line.Substring(idx + 1).Trim();
+
+            // Strip optional surrounding quotes.
+            if (value.Length >= 2 &&
+                ((value[0] == '"' && value[^1] == '"') || (value[0] == '\'' && value[^1] == '\'')))
+            {
+                value = value.Substring(1, value.Length - 2);
+            }
+
+            result[key] = value;
+        }
+
+        return result;
+    }
+
+    /// <summary>Walks up from the test binaries to the repository root and returns HedgehogPanel/.env if present.</summary>
+    private static string? FindEnvFile()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir, "HedgehogPanel.sln")))
+            {
+                var envPath = Path.Combine(dir, "HedgehogPanel", ".env");
+                return File.Exists(envPath) ? envPath : null;
+            }
+            dir = Directory.GetParent(dir)?.FullName;
+        }
+        return null;
+    }
+}

--- a/HedgehogPanel.Tests/Unit/Auth/AuthTokenTests.cs
+++ b/HedgehogPanel.Tests/Unit/Auth/AuthTokenTests.cs
@@ -1,0 +1,249 @@
+using Xunit;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Reflection;
+using HedgehogPanel.API.Auth;
+using HedgehogPanel.Infrastructure.Configuration;
+
+namespace HedgehogPanel.Tests.Unit.Auth;
+
+public class AuthTokenTests
+{
+    [Fact]
+    public void GenerateJwtToken_WithValidConfig_ReturnsToken()
+    {
+        // Arrange
+        var config = CreateValidConfig();
+        var claims = new List<Claim>
+        {
+            new Claim("username", "testuser"),
+            new Claim("guid", Guid.NewGuid().ToString())
+        };
+
+        // Act
+        var token = InvokeGenerateJwtToken(claims, config);
+
+        // Assert
+        Assert.NotNull(token);
+        Assert.NotEmpty(token);
+        Assert.Contains(".", token); // JWT has dots separating parts
+    }
+
+    [Fact]
+    public void GenerateJwtToken_WithNullSecret_ThrowsException()
+    {
+        // Arrange
+        var config = CreateValidConfig();
+        config.Auth.Jwt.Secret = null;
+        var claims = new List<Claim> { new Claim("username", "testuser") };
+
+        // Act & Assert
+        var exception = Assert.Throws<TargetInvocationException>(() => InvokeGenerateJwtToken(claims, config));
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Contains("JWT secret not configured", exception.InnerException.Message);
+    }
+
+    [Fact]
+    public void GenerateJwtToken_WithEmptySecret_ThrowsException()
+    {
+        // Arrange
+        var config = CreateValidConfig();
+        config.Auth.Jwt.Secret = "";
+        var claims = new List<Claim> { new Claim("username", "testuser") };
+
+        // Act & Assert
+        var exception = Assert.Throws<TargetInvocationException>(() => InvokeGenerateJwtToken(claims, config));
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Contains("JWT secret not configured", exception.InnerException.Message);
+    }
+
+    [Fact]
+    public void GenerateJwtToken_WithShortSecret_ThrowsException()
+    {
+        // Arrange
+        var config = CreateValidConfig();
+        config.Auth.Jwt.Secret = "tooshort"; // Less than 32 bytes
+        var claims = new List<Claim> { new Claim("username", "testuser") };
+
+        // Act & Assert
+        var exception = Assert.Throws<TargetInvocationException>(() => InvokeGenerateJwtToken(claims, config));
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Contains("JWT secret too short", exception.InnerException.Message);
+    }
+
+    [Fact]
+    public void VerifyToken_WithValidToken_ReturnsTrue()
+    {
+        // Arrange
+        var config = CreateValidConfig();
+        var claims = new List<Claim>
+        {
+            new Claim("username", "testuser"),
+            new Claim("guid", Guid.NewGuid().ToString())
+        };
+        var token = InvokeGenerateJwtToken(claims, config);
+
+        // Act
+        var result = AuthEndpoints.VerifyToken(token, config);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void VerifyToken_WithInvalidToken_ReturnsFalse()
+    {
+        // Arrange
+        var config = CreateValidConfig();
+        var invalidToken = "invalid.token.here";
+
+        // Act
+        var result = AuthEndpoints.VerifyToken(invalidToken, config);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void VerifyToken_WithNullSecret_ReturnsFalse()
+    {
+        // Arrange
+        var config = CreateValidConfig();
+        config.Auth.Jwt.Secret = null;
+        var token = "some.token.value";
+
+        // Act
+        var result = AuthEndpoints.VerifyToken(token, config);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void VerifyToken_WithShortSecret_ReturnsFalse()
+    {
+        // Arrange
+        var config = CreateValidConfig();
+        config.Auth.Jwt.Secret = "short";
+        var token = "some.token.value";
+
+        // Act
+        var result = AuthEndpoints.VerifyToken(token, config);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void VerifyToken_WithWrongSecret_ReturnsFalse()
+    {
+        // Arrange
+        var config1 = CreateValidConfig();
+        var config2 = CreateValidConfig();
+        config2.Auth.Jwt.Secret = "different-secret-key-that-is-long-enough-32bytes!";
+        
+        var claims = new List<Claim> { new Claim("username", "testuser") };
+        var token = InvokeGenerateJwtToken(claims, config1);
+
+        // Act
+        var result = AuthEndpoints.VerifyToken(token, config2);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void FormatTime_WithPositiveTimeSpan_ReturnsFormattedString()
+    {
+        // Arrange
+        var span = TimeSpan.FromMinutes(5).Add(TimeSpan.FromSeconds(30));
+
+        // Act
+        var result = InvokeFormatTime(span);
+
+        // Assert
+        Assert.Equal("05:30", result);
+    }
+
+    [Fact]
+    public void FormatTime_WithZeroTimeSpan_ReturnsZeroString()
+    {
+        // Arrange
+        var span = TimeSpan.Zero;
+
+        // Act
+        var result = InvokeFormatTime(span);
+
+        // Assert
+        Assert.Equal("00:00", result);
+    }
+
+    [Fact]
+    public void FormatTime_WithNegativeTimeSpan_ReturnsZeroString()
+    {
+        // Arrange
+        var span = TimeSpan.FromMinutes(-5);
+
+        // Act
+        var result = InvokeFormatTime(span);
+
+        // Assert
+        Assert.Equal("00:00", result);
+    }
+
+    [Fact]
+    public void FormatTime_WithLargeTimeSpan_ReturnsFormattedString()
+    {
+        // Arrange
+        var span = TimeSpan.FromMinutes(125).Add(TimeSpan.FromSeconds(45));
+
+        // Act
+        var result = InvokeFormatTime(span);
+
+        // Assert
+        Assert.Equal("125:45", result);
+    }
+
+    [Fact]
+    public void FormatTime_WithOnlySeconds_ReturnsFormattedString()
+    {
+        // Arrange
+        var span = TimeSpan.FromSeconds(45);
+
+        // Act
+        var result = InvokeFormatTime(span);
+
+        // Assert
+        Assert.Equal("00:45", result);
+    }
+
+    private HedgehogConfig CreateValidConfig()
+    {
+        return new HedgehogConfig
+        {
+            Auth = new AuthConfig
+            {
+                Jwt = new JwtConfig
+                {
+                    Secret = "this-is-a-very-long-secret-key-for-jwt-token-generation-32bytes",
+                    Issuer = "HedgehogPanel",
+                    Audience = "HedgehogPanel.Client",
+                    ExpiresInMinutes = 60
+                }
+            }
+        };
+    }
+
+    private string InvokeGenerateJwtToken(List<Claim> claims, HedgehogConfig config)
+    {
+        var method = typeof(AuthEndpoints).GetMethod("GenerateJwtToken", BindingFlags.NonPublic | BindingFlags.Static);
+        return (string)method!.Invoke(null, new object[] { claims, config })!;
+    }
+
+    private string InvokeFormatTime(TimeSpan span)
+    {
+        var method = typeof(AuthEndpoints).GetMethod("FormatTime", BindingFlags.NonPublic | BindingFlags.Static);
+        return (string)method!.Invoke(null, new object[] { span })!;
+    }
+}

--- a/HedgehogPanel.Tests/Unit/Configuration/ConfigLoaderTests.cs
+++ b/HedgehogPanel.Tests/Unit/Configuration/ConfigLoaderTests.cs
@@ -4,6 +4,7 @@ using HedgehogPanel.Infrastructure.Configuration;
 
 namespace HedgehogPanel.Tests.Unit.Configuration;
 
+[Collection("IntegrationTests")]
 public class ConfigLoaderTests
 {
     [Fact]
@@ -30,13 +31,13 @@ public class ConfigLoaderTests
         var originalHost = Environment.GetEnvironmentVariable("DB_HOST");
         try
         {
-            Environment.SetEnvironmentVariable("DB_HOST", "testhost.example.com");
+            Environment.SetEnvironmentVariable("DB_HOST", "testhost.hedgehog.batacek.eu");
 
             // Act
             var config = ConfigLoader.Load(args);
 
             // Assert
-            Assert.Equal("testhost.example.com", config.Database.Host);
+            Assert.Equal("testhost.hedgehog.batacek.eu", config.Database.Host);
         }
         finally
         {
@@ -191,7 +192,7 @@ public class ConfigLoaderTests
         var originalPassword = Environment.GetEnvironmentVariable("DB_PASSWORD");
         try
         {
-            Environment.SetEnvironmentVariable("DB_HOST", "multi.example.com");
+            Environment.SetEnvironmentVariable("DB_HOST", "multi.hedgehog.batacek.eu");
             Environment.SetEnvironmentVariable("DB_USER", "multiuser");
             Environment.SetEnvironmentVariable("DB_PASSWORD", "multipass");
 
@@ -199,7 +200,7 @@ public class ConfigLoaderTests
             var config = ConfigLoader.Load(args);
 
             // Assert
-            Assert.Equal("multi.example.com", config.Database.Host);
+            Assert.Equal("multi.hedgehog.batacek.eu", config.Database.Host);
             Assert.Equal("multiuser", config.Database.Username);
             Assert.Equal("multipass", config.Database.Password);
         }

--- a/HedgehogPanel.Tests/Unit/Configuration/ConfigLoaderTests.cs
+++ b/HedgehogPanel.Tests/Unit/Configuration/ConfigLoaderTests.cs
@@ -1,0 +1,266 @@
+using Xunit;
+using System;
+using HedgehogPanel.Infrastructure.Configuration;
+
+namespace HedgehogPanel.Tests.Unit.Configuration;
+
+public class ConfigLoaderTests
+{
+    [Fact]
+    public void Load_WithEmptyArgs_ReturnsDefaultConfig()
+    {
+        // Arrange
+        var args = Array.Empty<string>();
+
+        // Act
+        var config = ConfigLoader.Load(args);
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.NotNull(config.Database);
+        Assert.NotNull(config.Auth);
+        Assert.NotNull(config.Server);
+    }
+
+    [Fact]
+    public void Load_WithEnvironmentVariables_OverridesDbHost()
+    {
+        // Arrange
+        var args = Array.Empty<string>();
+        var originalHost = Environment.GetEnvironmentVariable("DB_HOST");
+        try
+        {
+            Environment.SetEnvironmentVariable("DB_HOST", "testhost.example.com");
+
+            // Act
+            var config = ConfigLoader.Load(args);
+
+            // Assert
+            Assert.Equal("testhost.example.com", config.Database.Host);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DB_HOST", originalHost);
+        }
+    }
+
+    [Fact]
+    public void Load_WithEnvironmentVariables_OverridesDbPort()
+    {
+        // Arrange
+        var args = Array.Empty<string>();
+        var originalPort = Environment.GetEnvironmentVariable("DB_PORT");
+        try
+        {
+            Environment.SetEnvironmentVariable("DB_PORT", "5433");
+
+            // Act
+            var config = ConfigLoader.Load(args);
+
+            // Assert
+            Assert.Equal(5433, config.Database.Port);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DB_PORT", originalPort);
+        }
+    }
+
+    [Fact]
+    public void Load_WithInvalidDbPort_KeepsDefaultPort()
+    {
+        // Arrange
+        var args = Array.Empty<string>();
+        var originalPort = Environment.GetEnvironmentVariable("DB_PORT");
+        var originalDbPort = 0;
+        try
+        {
+            // Get default port first
+            var defaultConfig = ConfigLoader.Load(Array.Empty<string>());
+            originalDbPort = defaultConfig.Database.Port;
+
+            Environment.SetEnvironmentVariable("DB_PORT", "invalid");
+
+            // Act
+            var config = ConfigLoader.Load(args);
+
+            // Assert
+            Assert.Equal(originalDbPort, config.Database.Port);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DB_PORT", originalPort);
+        }
+    }
+
+    [Fact]
+    public void Load_WithEnvironmentVariables_OverridesDbUser()
+    {
+        // Arrange
+        var args = Array.Empty<string>();
+        var originalUser = Environment.GetEnvironmentVariable("DB_USER");
+        try
+        {
+            Environment.SetEnvironmentVariable("DB_USER", "testuser");
+
+            // Act
+            var config = ConfigLoader.Load(args);
+
+            // Assert
+            Assert.Equal("testuser", config.Database.Username);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DB_USER", originalUser);
+        }
+    }
+
+    [Fact]
+    public void Load_WithEnvironmentVariables_OverridesDbPassword()
+    {
+        // Arrange
+        var args = Array.Empty<string>();
+        var originalPassword = Environment.GetEnvironmentVariable("DB_PASSWORD");
+        try
+        {
+            Environment.SetEnvironmentVariable("DB_PASSWORD", "testpass123");
+
+            // Act
+            var config = ConfigLoader.Load(args);
+
+            // Assert
+            Assert.Equal("testpass123", config.Database.Password);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DB_PASSWORD", originalPassword);
+        }
+    }
+
+    [Fact]
+    public void Load_WithEnvironmentVariables_OverridesDbName()
+    {
+        // Arrange
+        var args = Array.Empty<string>();
+        var originalName = Environment.GetEnvironmentVariable("DB_NAME");
+        try
+        {
+            Environment.SetEnvironmentVariable("DB_NAME", "testdb");
+
+            // Act
+            var config = ConfigLoader.Load(args);
+
+            // Assert
+            Assert.Equal("testdb", config.Database.Name);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DB_NAME", originalName);
+        }
+    }
+
+    [Fact]
+    public void Load_WithEnvironmentVariables_OverridesJwtSecret()
+    {
+        // Arrange
+        var args = Array.Empty<string>();
+        var originalSecret = Environment.GetEnvironmentVariable("JWT_SECRET");
+        try
+        {
+            Environment.SetEnvironmentVariable("JWT_SECRET", "test-secret-key-12345");
+
+            // Act
+            var config = ConfigLoader.Load(args);
+
+            // Assert
+            Assert.Equal("test-secret-key-12345", config.Auth.Jwt.Secret);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("JWT_SECRET", originalSecret);
+        }
+    }
+
+    [Fact]
+    public void Load_WithMultipleEnvironmentVariables_OverridesAll()
+    {
+        // Arrange
+        var args = Array.Empty<string>();
+        var originalHost = Environment.GetEnvironmentVariable("DB_HOST");
+        var originalUser = Environment.GetEnvironmentVariable("DB_USER");
+        var originalPassword = Environment.GetEnvironmentVariable("DB_PASSWORD");
+        try
+        {
+            Environment.SetEnvironmentVariable("DB_HOST", "multi.example.com");
+            Environment.SetEnvironmentVariable("DB_USER", "multiuser");
+            Environment.SetEnvironmentVariable("DB_PASSWORD", "multipass");
+
+            // Act
+            var config = ConfigLoader.Load(args);
+
+            // Assert
+            Assert.Equal("multi.example.com", config.Database.Host);
+            Assert.Equal("multiuser", config.Database.Username);
+            Assert.Equal("multipass", config.Database.Password);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DB_HOST", originalHost);
+            Environment.SetEnvironmentVariable("DB_USER", originalUser);
+            Environment.SetEnvironmentVariable("DB_PASSWORD", originalPassword);
+        }
+    }
+
+    [Fact]
+    public void Load_WithEmptyEnvironmentVariable_DoesNotOverride()
+    {
+        // Arrange
+        var args = Array.Empty<string>();
+        var originalHost = Environment.GetEnvironmentVariable("DB_HOST");
+        try
+        {
+            // Get default host first
+            var defaultConfig = ConfigLoader.Load(Array.Empty<string>());
+            var defaultHost = defaultConfig.Database.Host;
+
+            Environment.SetEnvironmentVariable("DB_HOST", "");
+
+            // Act
+            var config = ConfigLoader.Load(args);
+
+            // Assert
+            Assert.Equal(defaultHost, config.Database.Host);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DB_HOST", originalHost);
+        }
+    }
+
+    [Fact]
+    public void HedgehogConfig_DatabaseConnectionString_IsFormatted()
+    {
+        // Arrange
+        var config = new HedgehogConfig
+        {
+            Database = new DatabaseConfig
+            {
+                Host = "testhost",
+                Port = 5432,
+                Username = "testuser",
+                Password = "testpass",
+                Name = "testdb"
+            }
+        };
+
+        // Act
+        var connectionString = config.Database.ConnectionString;
+
+        // Assert
+        Assert.Contains("Host=testhost", connectionString);
+        Assert.Contains("Port=5432", connectionString);
+        Assert.Contains("Username=testuser", connectionString);
+        Assert.Contains("Password=testpass", connectionString);
+        Assert.Contains("Database=testdb", connectionString);
+    }
+}

--- a/HedgehogPanel.Tests/Unit/Domain/AccountTests.cs
+++ b/HedgehogPanel.Tests/Unit/Domain/AccountTests.cs
@@ -1,0 +1,133 @@
+using System;
+using HedgehogPanel.Domain.Entities;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Unit.Domain;
+
+public class AccountTests
+{
+    private static Account NewAccount(
+        string? first = null, string? middle = null, string? last = null,
+        Group[]? groups = null, bool isActive = true)
+        => new(Guid.NewGuid(), "user", "user@hedgehog.batacek.eu", isActive, null, first, middle, last, groups);
+
+    [Fact]
+    public void FullName_WithAllParts_JoinsWithSingleSpaces()
+    {
+        var account = NewAccount("John", "Q", "Public");
+        Assert.Equal("John Q Public", account.FullName);
+    }
+
+    [Fact]
+    public void FullName_WithMissingMiddle_OmitsIt()
+    {
+        var account = NewAccount("John", null, "Public");
+        Assert.Equal("John Public", account.FullName);
+    }
+
+    [Fact]
+    public void FullName_WithWhitespaceOnlyPart_OmitsIt()
+    {
+        var account = NewAccount("John", "   ", "Public");
+        Assert.Equal("John Public", account.FullName);
+    }
+
+    [Fact]
+    public void FullName_WithNoNameParts_ReturnsEmpty()
+    {
+        var account = NewAccount();
+        Assert.Equal(string.Empty, account.FullName);
+    }
+
+    [Fact]
+    public void IsAdmin_WhenInAdminGroup_ReturnsTrue()
+    {
+        var account = NewAccount(groups: new[] { new Group(Guid.NewGuid(), "admin") });
+        Assert.True(account.IsAdmin);
+    }
+
+    [Fact]
+    public void IsAdmin_WhenAdminGroupHasDifferentCasing_ReturnsTrue()
+    {
+        var account = NewAccount(groups: new[] { new Group(Guid.NewGuid(), "ADMIN") });
+        Assert.True(account.IsAdmin);
+    }
+
+    [Fact]
+    public void IsAdmin_WhenOnlyNonAdminGroups_ReturnsFalse()
+    {
+        var account = NewAccount(groups: new[]
+        {
+            new Group(Guid.NewGuid(), "users"),
+            new Group(Guid.NewGuid(), "operators")
+        });
+        Assert.False(account.IsAdmin);
+    }
+
+    [Fact]
+    public void IsAdmin_WhenNoGroups_ReturnsFalse()
+    {
+        var account = NewAccount();
+        Assert.False(account.IsAdmin);
+    }
+
+    [Fact]
+    public void Constructor_WithoutGroups_DefaultsToEmpty()
+    {
+        var account = NewAccount();
+        Assert.NotNull(account.Groups);
+        Assert.Empty(account.Groups);
+    }
+
+    [Fact]
+    public void Constructor_WithNullUsername_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new Account(Guid.NewGuid(), null!, "user@hedgehog.batacek.eu"));
+    }
+
+    [Fact]
+    public void Constructor_WithNullEmail_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new Account(Guid.NewGuid(), "user", null!));
+    }
+
+    [Fact]
+    public void Rename_WithValidUsername_UpdatesUsername()
+    {
+        var account = NewAccount();
+        account.Rename("newname");
+        Assert.Equal("newname", account.Username);
+    }
+
+    [Fact]
+    public void Rename_WithEmptyUsername_Throws()
+    {
+        var account = NewAccount();
+        Assert.Throws<ArgumentException>(() => account.Rename(""));
+    }
+
+    [Fact]
+    public void Rename_WithWhitespaceUsername_Throws()
+    {
+        var account = NewAccount();
+        Assert.Throws<ArgumentException>(() => account.Rename("   "));
+    }
+
+    [Fact]
+    public void Activate_SetsIsActiveTrue()
+    {
+        var account = NewAccount(isActive: false);
+        account.Activate();
+        Assert.True(account.IsActive);
+    }
+
+    [Fact]
+    public void Deactivate_SetsIsActiveFalse()
+    {
+        var account = NewAccount(isActive: true);
+        account.Deactivate();
+        Assert.False(account.IsActive);
+    }
+}

--- a/HedgehogPanel.Tests/Unit/Domain/GroupTests.cs
+++ b/HedgehogPanel.Tests/Unit/Domain/GroupTests.cs
@@ -1,0 +1,33 @@
+using System;
+using HedgehogPanel.Domain.Entities;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Unit.Domain;
+
+public class GroupTests
+{
+    [Fact]
+    public void Constructor_WithNullName_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new Group(Guid.NewGuid(), null!));
+    }
+
+    [Fact]
+    public void Constructor_StoresProvidedValues()
+    {
+        var id = Guid.NewGuid();
+        var group = new Group(id, "admin", "Administrators", localId: null, priority: 10);
+
+        Assert.Equal(id, group.Guid);
+        Assert.Equal("admin", group.Name);
+        Assert.Equal("Administrators", group.Description);
+        Assert.Equal(10, group.Priority);
+    }
+
+    [Fact]
+    public void Constructor_DefaultsPriorityToZero()
+    {
+        var group = new Group(Guid.NewGuid(), "users");
+        Assert.Equal(0, group.Priority);
+    }
+}

--- a/HedgehogPanel.Tests/Unit/Domain/NodeTests.cs
+++ b/HedgehogPanel.Tests/Unit/Domain/NodeTests.cs
@@ -1,0 +1,48 @@
+using System;
+using HedgehogPanel.Domain.Entities;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Unit.Domain;
+
+public class NodeTests
+{
+    [Fact]
+    public void UpdateStatus_ChangesStatusAndStampsLastSeen()
+    {
+        var node = new Node(Guid.NewGuid(), "node", "10.0.0.1", 50051);
+        Assert.Null(node.LastSeen);
+
+        node.UpdateStatus("Online");
+
+        Assert.Equal("Online", node.Status);
+        Assert.NotNull(node.LastSeen);
+    }
+
+    [Fact]
+    public void Constructor_WithNullName_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new Node(Guid.NewGuid(), null!, "10.0.0.1", 50051));
+    }
+
+    [Fact]
+    public void Constructor_WithNullIpAddress_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new Node(Guid.NewGuid(), "node", null!, 50051));
+    }
+
+    [Fact]
+    public void Constructor_StoresProvidedValues()
+    {
+        var id = Guid.NewGuid();
+        var node = new Node(id, "node", "10.0.0.1", 50051, description: "desc", status: "Online");
+
+        Assert.Equal(id, node.Guid);
+        Assert.Equal("node", node.Name);
+        Assert.Equal("10.0.0.1", node.IpAddress);
+        Assert.Equal(50051, node.Port);
+        Assert.Equal("desc", node.Description);
+        Assert.Equal("Online", node.Status);
+    }
+}

--- a/HedgehogPanel.Tests/Unit/Domain/ServerTests.cs
+++ b/HedgehogPanel.Tests/Unit/Domain/ServerTests.cs
@@ -1,0 +1,58 @@
+using System;
+using HedgehogPanel.Domain.Entities;
+using HedgehogPanel.Domain.Enums;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Unit.Domain;
+
+public class ServerTests
+{
+    [Fact]
+    public void UpdateStatus_ChangesStatusAndStampsLastSeen()
+    {
+        var server = new Server(Guid.NewGuid(), "srv", "host.hedgehog.batacek.eu");
+        Assert.Null(server.LastSeen);
+
+        server.UpdateStatus(ServerStatus.Online);
+
+        Assert.Equal(ServerStatus.Online, server.Status);
+        Assert.NotNull(server.LastSeen);
+    }
+
+    [Fact]
+    public void Constructor_DefaultsStatusToUnknownAndPortTo22()
+    {
+        var server = new Server(Guid.NewGuid(), "srv", "host.hedgehog.batacek.eu");
+
+        Assert.Equal(ServerStatus.Unknown, server.Status);
+        Assert.Equal(22, server.DaemonPort);
+    }
+
+    [Fact]
+    public void Constructor_WithNullName_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new Server(Guid.NewGuid(), null!, "host.hedgehog.batacek.eu"));
+    }
+
+    [Fact]
+    public void Constructor_WithNullHostname_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new Server(Guid.NewGuid(), "srv", null!));
+    }
+
+    [Fact]
+    public void Constructor_StoresProvidedValues()
+    {
+        var id = Guid.NewGuid();
+        var server = new Server(id, "srv", "host.hedgehog.batacek.eu", 2222, ServerStatus.Offline, description: "desc");
+
+        Assert.Equal(id, server.Guid);
+        Assert.Equal("srv", server.Name);
+        Assert.Equal("host.hedgehog.batacek.eu", server.Hostname);
+        Assert.Equal(2222, server.DaemonPort);
+        Assert.Equal(ServerStatus.Offline, server.Status);
+        Assert.Equal("desc", server.Description);
+    }
+}

--- a/HedgehogPanel.Tests/Unit/Services/AccountLockoutServiceTests.cs
+++ b/HedgehogPanel.Tests/Unit/Services/AccountLockoutServiceTests.cs
@@ -1,0 +1,201 @@
+using Xunit;
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using HedgehogPanel.Infrastructure.Security;
+
+namespace HedgehogPanel.Tests.Unit.Services;
+
+public class AccountLockoutServiceTests
+{
+    private readonly Mock<IMemoryCache> _mockCache;
+    private readonly AccountLockoutService _service;
+
+    public AccountLockoutServiceTests()
+    {
+        _mockCache = new Mock<IMemoryCache>();
+        _service = new AccountLockoutService(_mockCache.Object);
+    }
+
+    [Fact]
+    public async Task IsAccountLockedAsync_WhenNoLockoutInfo_ReturnsFalse()
+    {
+        // Arrange
+        object? cacheValue = null;
+        _mockCache.Setup(c => c.TryGetValue(It.IsAny<object>(), out cacheValue)).Returns(false);
+        _mockCache.Setup(c => c.CreateEntry(It.IsAny<object>())).Returns(Mock.Of<ICacheEntry>());
+
+        // Act
+        var result = await _service.IsAccountLockedAsync("testuser", "127.0.0.1");
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsAccountLockedAsync_WhenLockedUntilInFuture_ReturnsTrue()
+    {
+        // Arrange
+        var lockoutInfo = CreateLockoutInfo();
+        lockoutInfo.GetType().GetProperty("LockedUntil")!.SetValue(lockoutInfo, DateTimeOffset.UtcNow.AddMinutes(5));
+        
+        object? cacheValue = lockoutInfo;
+        _mockCache.Setup(c => c.TryGetValue(It.IsAny<object>(), out cacheValue)).Returns(true);
+        _mockCache.Setup(c => c.CreateEntry(It.IsAny<object>())).Returns(Mock.Of<ICacheEntry>());
+
+        // Act
+        var result = await _service.IsAccountLockedAsync("testuser", "127.0.0.1");
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsAccountLockedAsync_WhenLockedUntilInPast_ReturnsFalse()
+    {
+        // Arrange
+        var lockoutInfo = CreateLockoutInfo();
+        lockoutInfo.GetType().GetProperty("LockedUntil")!.SetValue(lockoutInfo, DateTimeOffset.UtcNow.AddMinutes(-1));
+        
+        object? cacheValue = lockoutInfo;
+        _mockCache.Setup(c => c.TryGetValue(It.IsAny<object>(), out cacheValue)).Returns(true);
+        _mockCache.Setup(c => c.CreateEntry(It.IsAny<object>())).Returns(Mock.Of<ICacheEntry>());
+
+        // Act
+        var result = await _service.IsAccountLockedAsync("testuser", "127.0.0.1");
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task RecordFailedAttemptAsync_FirstAttempt_DoesNotLockAccount()
+    {
+        // Arrange
+        object? cacheValue = null;
+        _mockCache.Setup(c => c.TryGetValue(It.IsAny<object>(), out cacheValue)).Returns(false);
+        var mockEntry = new Mock<ICacheEntry>();
+        mockEntry.SetupProperty(e => e.Value);
+        _mockCache.Setup(c => c.CreateEntry(It.IsAny<object>())).Returns(mockEntry.Object);
+
+        // Act
+        await _service.RecordFailedAttemptAsync("testuser", "127.0.0.1");
+
+        // Assert
+        _mockCache.Verify(c => c.CreateEntry(It.IsAny<object>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task RecordFailedAttemptAsync_FifthAttempt_LocksAccount()
+    {
+        // Arrange
+        var lockoutInfo = CreateLockoutInfo();
+        var timestamps = lockoutInfo.GetType().GetProperty("FailedTimestamps")!.GetValue(lockoutInfo) as System.Collections.Generic.List<DateTimeOffset>;
+        for (int i = 0; i < 4; i++)
+        {
+            timestamps!.Add(DateTimeOffset.UtcNow.AddMinutes(-i));
+        }
+
+        object? cacheValue = lockoutInfo;
+        _mockCache.Setup(c => c.TryGetValue(It.IsAny<object>(), out cacheValue)).Returns(true);
+        var mockEntry = new Mock<ICacheEntry>();
+        mockEntry.SetupProperty(e => e.Value);
+        _mockCache.Setup(c => c.CreateEntry(It.IsAny<object>())).Returns(mockEntry.Object);
+
+        // Act
+        await _service.RecordFailedAttemptAsync("testuser", "127.0.0.1");
+
+        // Assert
+        var lockedUntil = lockoutInfo.GetType().GetProperty("LockedUntil")!.GetValue(lockoutInfo) as DateTimeOffset?;
+        Assert.NotNull(lockedUntil);
+        Assert.True(lockedUntil > DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public async Task GetLockoutTimeRemainingAsync_WhenNotLocked_ReturnsNull()
+    {
+        // Arrange
+        object? cacheValue = null;
+        _mockCache.Setup(c => c.TryGetValue(It.IsAny<object>(), out cacheValue)).Returns(false);
+        _mockCache.Setup(c => c.CreateEntry(It.IsAny<object>())).Returns(Mock.Of<ICacheEntry>());
+
+        // Act
+        var result = await _service.GetLockoutTimeRemainingAsync("testuser", "127.0.0.1");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetLockoutTimeRemainingAsync_WhenLocked_ReturnsTimeSpan()
+    {
+        // Arrange
+        var lockoutInfo = CreateLockoutInfo();
+        var futureTime = DateTimeOffset.UtcNow.AddMinutes(5);
+        lockoutInfo.GetType().GetProperty("LockedUntil")!.SetValue(lockoutInfo, futureTime);
+        
+        object? cacheValue = lockoutInfo;
+        _mockCache.Setup(c => c.TryGetValue(It.IsAny<object>(), out cacheValue)).Returns(true);
+        _mockCache.Setup(c => c.CreateEntry(It.IsAny<object>())).Returns(Mock.Of<ICacheEntry>());
+
+        // Act
+        var result = await _service.GetLockoutTimeRemainingAsync("testuser", "127.0.0.1");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.Value.TotalMinutes > 4 && result.Value.TotalMinutes <= 5);
+    }
+
+    [Fact]
+    public async Task ResetFailedAttemptsAsync_RemovesCacheEntry()
+    {
+        // Arrange & Act
+        await _service.ResetFailedAttemptsAsync("testuser", "127.0.0.1");
+
+        // Assert
+        _mockCache.Verify(c => c.Remove(It.IsAny<object>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UnlockAccountAsync_RemovesCacheEntry()
+    {
+        // Arrange & Act
+        await _service.UnlockAccountAsync("testuser", "127.0.0.1");
+
+        // Assert
+        _mockCache.Verify(c => c.Remove(It.IsAny<object>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RecordFailedAttemptAsync_OldAttemptsOutsideWindow_AreIgnored()
+    {
+        // Arrange
+        var lockoutInfo = CreateLockoutInfo();
+        var timestamps = lockoutInfo.GetType().GetProperty("FailedTimestamps")!.GetValue(lockoutInfo) as System.Collections.Generic.List<DateTimeOffset>;
+        // Add 4 old attempts (outside 15-minute window)
+        for (int i = 0; i < 4; i++)
+        {
+            timestamps!.Add(DateTimeOffset.UtcNow.AddMinutes(-20 - i));
+        }
+
+        object? cacheValue = lockoutInfo;
+        _mockCache.Setup(c => c.TryGetValue(It.IsAny<object>(), out cacheValue)).Returns(true);
+        var mockEntry = new Mock<ICacheEntry>();
+        mockEntry.SetupProperty(e => e.Value);
+        _mockCache.Setup(c => c.CreateEntry(It.IsAny<object>())).Returns(mockEntry.Object);
+
+        // Act
+        await _service.RecordFailedAttemptAsync("testuser", "127.0.0.1");
+
+        // Assert - should not be locked because old attempts are cleaned up
+        var lockedUntil = lockoutInfo.GetType().GetProperty("LockedUntil")!.GetValue(lockoutInfo) as DateTimeOffset?;
+        Assert.Null(lockedUntil);
+    }
+
+    private object CreateLockoutInfo()
+    {
+        var type = typeof(AccountLockoutService).GetNestedType("LockoutInfo", System.Reflection.BindingFlags.NonPublic);
+        return Activator.CreateInstance(type!)!;
+    }
+}

--- a/HedgehogPanel.Tests/Unit/Services/AccountServiceTests.cs
+++ b/HedgehogPanel.Tests/Unit/Services/AccountServiceTests.cs
@@ -26,7 +26,7 @@ public class AccountServiceTests
     {
         // Arrange
         var username = "testuser";
-        var email = "test@example.com";
+        var email = "test@hedgehog.batacek.eu";
         var password = "securepass123";
         _mockRepo.Setup(r => r.CreateAsync(It.IsAny<Account>(), It.IsAny<string>())).ReturnsAsync(true);
 
@@ -48,7 +48,7 @@ public class AccountServiceTests
         _mockRepo.Setup(r => r.CreateAsync(It.IsAny<Account>(), It.IsAny<string>())).ReturnsAsync(false);
 
         // Act & Assert
-        var exception = await Assert.ThrowsAsync<Exception>(() => _service.CreateAccountAsync("user", "mail@example.com", "pass"));
+        var exception = await Assert.ThrowsAsync<Exception>(() => _service.CreateAccountAsync("user", "mail@hedgehog.batacek.eu", "pass"));
         Assert.Equal("Failed to create account", exception.Message);
     }
 
@@ -66,7 +66,7 @@ public class AccountServiceTests
     public async Task AuthenticateAsync_WithValidInputs_CallsRepository()
     {
         // Arrange
-        var expectedAccount = new Account(Guid.NewGuid(), "validuser", "valid@example.com", true, null);
+        var expectedAccount = new Account(Guid.NewGuid(), "validuser", "valid@hedgehog.batacek.eu", true, null);
         _mockRepo.Setup(r => r.AuthenticateAsync("validuser", "validpass")).ReturnsAsync(expectedAccount);
 
         // Act
@@ -83,7 +83,7 @@ public class AccountServiceTests
     {
         // Arrange
         var guid = Guid.NewGuid();
-        var expectedAccount = new Account(guid, "user", "mail@example.com", true, null);
+        var expectedAccount = new Account(guid, "user", "mail@hedgehog.batacek.eu", true, null);
         _mockRepo.Setup(r => r.GetByUsernameAsync("user")).ReturnsAsync(expectedAccount);
 
         // Act

--- a/HedgehogPanel.Tests/Unit/Services/AccountServiceTests.cs
+++ b/HedgehogPanel.Tests/Unit/Services/AccountServiceTests.cs
@@ -1,0 +1,179 @@
+using Xunit;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using HedgehogPanel.Application.Services;
+using HedgehogPanel.Application.Repositories;
+using HedgehogPanel.Domain.Entities;
+
+namespace HedgehogPanel.Tests.Unit.Services;
+
+public class AccountServiceTests
+{
+    private readonly Mock<IAccountRepository> _mockRepo;
+    private readonly AccountService _service;
+
+    public AccountServiceTests()
+    {
+        _mockRepo = new Mock<IAccountRepository>();
+        _service = new AccountService(_mockRepo.Object);
+    }
+
+    [Fact]
+    public async Task CreateAccountAsync_WithValidInputs_ReturnsCreatedAccount()
+    {
+        // Arrange
+        var username = "testuser";
+        var email = "test@example.com";
+        var password = "securepass123";
+        _mockRepo.Setup(r => r.CreateAsync(It.IsAny<Account>(), It.IsAny<string>())).ReturnsAsync(true);
+
+        // Act
+        var result = await _service.CreateAccountAsync(username, email, password);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(username, result.Username);
+        Assert.Equal(email, result.Email);
+        _mockRepo.Verify(r => r.CreateAsync(It.Is<Account>(a => 
+            a.Username == username && a.Email == email), password), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAccountAsync_WhenRepoFails_ThrowsException()
+    {
+        // Arrange
+        _mockRepo.Setup(r => r.CreateAsync(It.IsAny<Account>(), It.IsAny<string>())).ReturnsAsync(false);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<Exception>(() => _service.CreateAccountAsync("user", "mail@example.com", "pass"));
+        Assert.Equal("Failed to create account", exception.Message);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WithEmptyInputs_ReturnsNull()
+    {
+        // Act & Assert
+        Assert.Null(await _service.AuthenticateAsync("", "pass"));
+        Assert.Null(await _service.AuthenticateAsync("user", ""));
+        Assert.Null(await _service.AuthenticateAsync("", ""));
+        _mockRepo.Verify(r => r.AuthenticateAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_WithValidInputs_CallsRepository()
+    {
+        // Arrange
+        var expectedAccount = new Account(Guid.NewGuid(), "validuser", "valid@example.com", true, null);
+        _mockRepo.Setup(r => r.AuthenticateAsync("validuser", "validpass")).ReturnsAsync(expectedAccount);
+
+        // Act
+        var result = await _service.AuthenticateAsync("validuser", "validpass");
+
+        // Assert
+        Assert.Equal(expectedAccount.Guid, result.Guid);
+        Assert.Equal("validuser", result.Username);
+        _mockRepo.Verify(r => r.AuthenticateAsync("validuser", "validpass"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAccountByUsernameAsync_CallsRepository()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+        var expectedAccount = new Account(guid, "user", "mail@example.com", true, null);
+        _mockRepo.Setup(r => r.GetByUsernameAsync("user")).ReturnsAsync(expectedAccount);
+
+        // Act
+        var result = await _service.GetAccountByUsernameAsync("user");
+
+        // Assert
+        Assert.Equal(guid, result.Guid);
+        _mockRepo.Verify(r => r.GetByUsernameAsync("user"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAccountByIdAsync_CallsRepository()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+        var expectedAccount = new Account(guid, "user", "mail", true, null);
+        _mockRepo.Setup(r => r.GetByGuidAsync(guid)).ReturnsAsync(expectedAccount);
+
+        // Act
+        var result = await _service.GetAccountByIdAsync(guid);
+
+        // Assert
+        Assert.Equal(guid, result.Guid);
+        _mockRepo.Verify(r => r.GetByGuidAsync(guid), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAccountAsync_CallsRepositoryReturnsTrue()
+    {
+        // Arrange
+        var account = new Account(Guid.NewGuid(), "user", "mail", true, null);
+        _mockRepo.Setup(r => r.UpdateAsync(account, null)).ReturnsAsync(true);
+
+        // Act
+        var result = await _service.UpdateAccountAsync(account);
+
+        // Assert
+        Assert.True(result);
+        _mockRepo.Verify(r => r.UpdateAsync(account, null), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAccountAsync_AccountNotFound_ReturnsFalse()
+    {
+        // Arrange
+        _mockRepo.Setup(r => r.GetByUsernameAsync("nonexistent")).ReturnsAsync((Account?)null);
+
+        // Act
+        var result = await _service.DeleteAccountAsync("nonexistent");
+
+        // Assert
+        Assert.False(result);
+        _mockRepo.Verify(r => r.GetByUsernameAsync("nonexistent"), Times.Once);
+        _mockRepo.Verify(r => r.DeleteAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAccountAsync_ValidAccount_CallsDelete()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+        var account = new Account(guid, "user", "mail", true, null);
+        _mockRepo.Setup(r => r.GetByUsernameAsync("user")).ReturnsAsync(account);
+        _mockRepo.Setup(r => r.DeleteAsync(guid)).ReturnsAsync(true);
+
+        // Act
+        var result = await _service.DeleteAccountAsync("user");
+
+        // Assert
+        Assert.True(result);
+        _mockRepo.Verify(r => r.DeleteAsync(guid), Times.Once);
+    }
+
+    [Fact]
+    public async Task ListAccountsAsync_CallsRepository()
+    {
+        // Arrange
+        var accounts = new List<Account>
+        {
+            new Account(Guid.NewGuid(), "user1", "mail1", true, null),
+            new Account(Guid.NewGuid(), "user2", "mail2", true, null)
+        };
+        _mockRepo.Setup(r => r.ListAsync(5, 0)).ReturnsAsync(accounts);
+
+        // Act
+        var result = await _service.ListAccountsAsync(5, 0);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("user1", result.First().Username);
+        _mockRepo.Verify(r => r.ListAsync(5, 0), Times.Once);
+    }
+}

--- a/HedgehogPanel.Tests/Unit/Services/ServerServiceTests.cs
+++ b/HedgehogPanel.Tests/Unit/Services/ServerServiceTests.cs
@@ -1,0 +1,273 @@
+using Xunit;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HedgehogPanel.Application.Services;
+using HedgehogPanel.Application.Repositories;
+using HedgehogPanel.Domain.Entities;
+using HedgehogPanel.Domain.Enums;
+
+namespace HedgehogPanel.Tests.Unit.Services;
+
+public class ServerServiceTests
+{
+    private readonly Mock<IServerRepository> _mockRepo;
+    private readonly ServerService _service;
+
+    public ServerServiceTests()
+    {
+        _mockRepo = new Mock<IServerRepository>();
+        _service = new ServerService(_mockRepo.Object);
+    }
+
+    [Fact]
+    public async Task CreateServerAsync_WithValidInputs_ReturnsCreatedServer()
+    {
+        // Arrange
+        var name = "TestServer";
+        var hostname = "test.example.com";
+        var port = 22;
+        _mockRepo.Setup(r => r.CreateAsync(It.IsAny<Server>())).ReturnsAsync(true);
+
+        // Act
+        var result = await _service.CreateServerAsync(name, hostname, port);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(name, result.Name);
+        Assert.Equal(hostname, result.Hostname);
+        Assert.Equal(port, result.DaemonPort);
+        _mockRepo.Verify(r => r.CreateAsync(It.Is<Server>(s => 
+            s.Name == name && s.Hostname == hostname && s.DaemonPort == port)), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateServerAsync_WhenRepoFails_ThrowsException()
+    {
+        // Arrange
+        _mockRepo.Setup(r => r.CreateAsync(It.IsAny<Server>())).ReturnsAsync(false);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<Exception>(() => 
+            _service.CreateServerAsync("server", "host.com", 22));
+        Assert.Equal("Failed to create server", exception.Message);
+    }
+
+    [Fact]
+    public async Task GetServerByIdAsync_CallsRepository()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+        var expectedServer = new Server(guid, "TestServer", "test.com", 22);
+        _mockRepo.Setup(r => r.GetByGuidAsync(guid)).ReturnsAsync(expectedServer);
+
+        // Act
+        var result = await _service.GetServerByIdAsync(guid);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(guid, result.Guid);
+        Assert.Equal("TestServer", result.Name);
+        _mockRepo.Verify(r => r.GetByGuidAsync(guid), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetServerByIdAsync_WhenNotFound_ReturnsNull()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+        _mockRepo.Setup(r => r.GetByGuidAsync(guid)).ReturnsAsync((Server?)null);
+
+        // Act
+        var result = await _service.GetServerByIdAsync(guid);
+
+        // Assert
+        Assert.Null(result);
+        _mockRepo.Verify(r => r.GetByGuidAsync(guid), Times.Once);
+    }
+
+    [Fact]
+    public async Task ListServersAsync_CallsRepository()
+    {
+        // Arrange
+        var servers = new List<Server>
+        {
+            new Server(Guid.NewGuid(), "Server1", "host1.com", 22),
+            new Server(Guid.NewGuid(), "Server2", "host2.com", 22)
+        };
+        _mockRepo.Setup(r => r.ListAsync(100, 0)).ReturnsAsync(servers);
+
+        // Act
+        var result = await _service.ListServersAsync(100, 0);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Server1", result[0].Name);
+        Assert.Equal("Server2", result[1].Name);
+        _mockRepo.Verify(r => r.ListAsync(100, 0), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateServerAsync_CallsRepositoryReturnsTrue()
+    {
+        // Arrange
+        var server = new Server(Guid.NewGuid(), "UpdatedServer", "updated.com", 2222);
+        _mockRepo.Setup(r => r.UpdateAsync(server)).ReturnsAsync(true);
+
+        // Act
+        var result = await _service.UpdateServerAsync(server);
+
+        // Assert
+        Assert.True(result);
+        _mockRepo.Verify(r => r.UpdateAsync(server), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateServerAsync_WhenRepoFails_ReturnsFalse()
+    {
+        // Arrange
+        var server = new Server(Guid.NewGuid(), "Server", "host.com", 22);
+        _mockRepo.Setup(r => r.UpdateAsync(server)).ReturnsAsync(false);
+
+        // Act
+        var result = await _service.UpdateServerAsync(server);
+
+        // Assert
+        Assert.False(result);
+        _mockRepo.Verify(r => r.UpdateAsync(server), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteServerAsync_CallsRepositoryReturnsTrue()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+        _mockRepo.Setup(r => r.DeleteAsync(guid)).ReturnsAsync(true);
+
+        // Act
+        var result = await _service.DeleteServerAsync(guid);
+
+        // Assert
+        Assert.True(result);
+        _mockRepo.Verify(r => r.DeleteAsync(guid), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteServerAsync_WhenNotFound_ReturnsFalse()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+        _mockRepo.Setup(r => r.DeleteAsync(guid)).ReturnsAsync(false);
+
+        // Act
+        var result = await _service.DeleteServerAsync(guid);
+
+        // Assert
+        Assert.False(result);
+        _mockRepo.Verify(r => r.DeleteAsync(guid), Times.Once);
+    }
+
+    [Fact]
+    public async Task ListServersByOwnerAsync_CallsRepository()
+    {
+        // Arrange
+        var ownerGuid = Guid.NewGuid();
+        var servers = new List<Server>
+        {
+            new Server(Guid.NewGuid(), "OwnedServer1", "host1.com", 22),
+            new Server(Guid.NewGuid(), "OwnedServer2", "host2.com", 22)
+        };
+        _mockRepo.Setup(r => r.ListByOwnerAsync(ownerGuid, 100, 0)).ReturnsAsync(servers);
+
+        // Act
+        var result = await _service.ListServersByOwnerAsync(ownerGuid, 100, 0);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("OwnedServer1", result[0].Name);
+        _mockRepo.Verify(r => r.ListByOwnerAsync(ownerGuid, 100, 0), Times.Once);
+    }
+
+    [Fact]
+    public async Task ListUnownedServersAsync_CallsRepository()
+    {
+        // Arrange
+        var servers = new List<Server>
+        {
+            new Server(Guid.NewGuid(), "UnownedServer", "host.com", 22)
+        };
+        _mockRepo.Setup(r => r.ListUnownedAsync(100, 0)).ReturnsAsync(servers);
+
+        // Act
+        var result = await _service.ListUnownedServersAsync(100, 0);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("UnownedServer", result[0].Name);
+        _mockRepo.Verify(r => r.ListUnownedAsync(100, 0), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetServerOwnerUsernameAsync_CallsRepository()
+    {
+        // Arrange
+        var serverGuid = Guid.NewGuid();
+        var ownerUsername = "testowner";
+        _mockRepo.Setup(r => r.GetOwnerUsernameAsync(serverGuid)).ReturnsAsync(ownerUsername);
+
+        // Act
+        var result = await _service.GetServerOwnerUsernameAsync(serverGuid);
+
+        // Assert
+        Assert.Equal(ownerUsername, result);
+        _mockRepo.Verify(r => r.GetOwnerUsernameAsync(serverGuid), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetServerOwnerUsernameAsync_WhenNoOwner_ReturnsNull()
+    {
+        // Arrange
+        var serverGuid = Guid.NewGuid();
+        _mockRepo.Setup(r => r.GetOwnerUsernameAsync(serverGuid)).ReturnsAsync((string?)null);
+
+        // Act
+        var result = await _service.GetServerOwnerUsernameAsync(serverGuid);
+
+        // Assert
+        Assert.Null(result);
+        _mockRepo.Verify(r => r.GetOwnerUsernameAsync(serverGuid), Times.Once);
+    }
+
+    [Fact]
+    public async Task AssignServerToUserAsync_CallsRepositoryReturnsTrue()
+    {
+        // Arrange
+        var serverGuid = Guid.NewGuid();
+        var userGuid = Guid.NewGuid();
+        _mockRepo.Setup(r => r.AssignToUserAsync(serverGuid, userGuid)).ReturnsAsync(true);
+
+        // Act
+        var result = await _service.AssignServerToUserAsync(serverGuid, userGuid);
+
+        // Assert
+        Assert.True(result);
+        _mockRepo.Verify(r => r.AssignToUserAsync(serverGuid, userGuid), Times.Once);
+    }
+
+    [Fact]
+    public async Task AssignServerToUserAsync_WhenFails_ReturnsFalse()
+    {
+        // Arrange
+        var serverGuid = Guid.NewGuid();
+        var userGuid = Guid.NewGuid();
+        _mockRepo.Setup(r => r.AssignToUserAsync(serverGuid, userGuid)).ReturnsAsync(false);
+
+        // Act
+        var result = await _service.AssignServerToUserAsync(serverGuid, userGuid);
+
+        // Assert
+        Assert.False(result);
+        _mockRepo.Verify(r => r.AssignToUserAsync(serverGuid, userGuid), Times.Once);
+    }
+}

--- a/HedgehogPanel.Tests/Unit/Services/ServerServiceTests.cs
+++ b/HedgehogPanel.Tests/Unit/Services/ServerServiceTests.cs
@@ -26,7 +26,7 @@ public class ServerServiceTests
     {
         // Arrange
         var name = "TestServer";
-        var hostname = "test.example.com";
+        var hostname = "test.hedgehog.batacek.eu";
         var port = 22;
         _mockRepo.Setup(r => r.CreateAsync(It.IsAny<Server>())).ReturnsAsync(true);
 
@@ -50,7 +50,7 @@ public class ServerServiceTests
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<Exception>(() => 
-            _service.CreateServerAsync("server", "host.com", 22));
+            _service.CreateServerAsync("server", "host.hedgehog.batacek.eu", 22));
         Assert.Equal("Failed to create server", exception.Message);
     }
 
@@ -59,7 +59,7 @@ public class ServerServiceTests
     {
         // Arrange
         var guid = Guid.NewGuid();
-        var expectedServer = new Server(guid, "TestServer", "test.com", 22);
+        var expectedServer = new Server(guid, "TestServer", "test.hedgehog.batacek.eu", 22);
         _mockRepo.Setup(r => r.GetByGuidAsync(guid)).ReturnsAsync(expectedServer);
 
         // Act
@@ -93,8 +93,8 @@ public class ServerServiceTests
         // Arrange
         var servers = new List<Server>
         {
-            new Server(Guid.NewGuid(), "Server1", "host1.com", 22),
-            new Server(Guid.NewGuid(), "Server2", "host2.com", 22)
+            new Server(Guid.NewGuid(), "Server1", "host1.hedgehog.batacek.eu", 22),
+            new Server(Guid.NewGuid(), "Server2", "host2.hedgehog.batacek.eu", 22)
         };
         _mockRepo.Setup(r => r.ListAsync(100, 0)).ReturnsAsync(servers);
 
@@ -112,7 +112,7 @@ public class ServerServiceTests
     public async Task UpdateServerAsync_CallsRepositoryReturnsTrue()
     {
         // Arrange
-        var server = new Server(Guid.NewGuid(), "UpdatedServer", "updated.com", 2222);
+        var server = new Server(Guid.NewGuid(), "UpdatedServer", "updated.hedgehog.batacek.eu", 2222);
         _mockRepo.Setup(r => r.UpdateAsync(server)).ReturnsAsync(true);
 
         // Act
@@ -127,7 +127,7 @@ public class ServerServiceTests
     public async Task UpdateServerAsync_WhenRepoFails_ReturnsFalse()
     {
         // Arrange
-        var server = new Server(Guid.NewGuid(), "Server", "host.com", 22);
+        var server = new Server(Guid.NewGuid(), "Server", "host.hedgehog.batacek.eu", 22);
         _mockRepo.Setup(r => r.UpdateAsync(server)).ReturnsAsync(false);
 
         // Act
@@ -175,8 +175,8 @@ public class ServerServiceTests
         var ownerGuid = Guid.NewGuid();
         var servers = new List<Server>
         {
-            new Server(Guid.NewGuid(), "OwnedServer1", "host1.com", 22),
-            new Server(Guid.NewGuid(), "OwnedServer2", "host2.com", 22)
+            new Server(Guid.NewGuid(), "OwnedServer1", "host1.hedgehog.batacek.eu", 22),
+            new Server(Guid.NewGuid(), "OwnedServer2", "host2.hedgehog.batacek.eu", 22)
         };
         _mockRepo.Setup(r => r.ListByOwnerAsync(ownerGuid, 100, 0)).ReturnsAsync(servers);
 
@@ -195,7 +195,7 @@ public class ServerServiceTests
         // Arrange
         var servers = new List<Server>
         {
-            new Server(Guid.NewGuid(), "UnownedServer", "host.com", 22)
+            new Server(Guid.NewGuid(), "UnownedServer", "host.hedgehog.batacek.eu", 22)
         };
         _mockRepo.Setup(r => r.ListUnownedAsync(100, 0)).ReturnsAsync(servers);
 

--- a/HedgehogPanel.Tests/Unit/Store/DataProviderTests.cs
+++ b/HedgehogPanel.Tests/Unit/Store/DataProviderTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HedgehogPanel.Application.Contracts.Logging;
+using HedgehogPanel.Application.Services;
+using HedgehogPanel.Domain.Entities;
+using HedgehogPanel.Infrastructure.Configuration;
+using HedgehogPanel.Infrastructure.Persistence.Store;
+using Moq;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Unit.Store;
+
+public class DataProviderTests
+{
+    private readonly Mock<IAccountService> _accountService = new();
+    private readonly Mock<IServerService> _serverService = new();
+
+    private DataProvider CreateProvider(bool cacheEnabled, out InMemoryStore store)
+    {
+        var config = new HedgehogConfig { Cache = new CacheConfig { Enabled = cacheEnabled, TtlMinutes = 0 } };
+        store = new InMemoryStore(Mock.Of<ILoggerService>(), config);
+        return new DataProvider(store, _accountService.Object, _serverService.Object, Mock.Of<ILoggerService>(), config);
+    }
+
+    [Fact]
+    public async Task GetAccountByUsernameAsync_WhenCacheDisabled_CallsServiceEveryTime()
+    {
+        var provider = CreateProvider(cacheEnabled: false, out _);
+        var account = new Account(Guid.NewGuid(), "joe", "joe@hedgehog.batacek.eu");
+        _accountService.Setup(s => s.GetAccountByUsernameAsync("joe")).ReturnsAsync(account);
+
+        await provider.GetAccountByUsernameAsync("joe");
+        await provider.GetAccountByUsernameAsync("joe");
+
+        _accountService.Verify(s => s.GetAccountByUsernameAsync("joe"), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task GetAccountByUsernameAsync_CacheMiss_ThenSecondCallIsServedFromCache()
+    {
+        var provider = CreateProvider(cacheEnabled: true, out _);
+        var account = new Account(Guid.NewGuid(), "joe", "joe@hedgehog.batacek.eu");
+        _accountService.Setup(s => s.GetAccountByUsernameAsync("joe")).ReturnsAsync(account);
+
+        var first = await provider.GetAccountByUsernameAsync("joe");
+        var second = await provider.GetAccountByUsernameAsync("joe");
+
+        Assert.Same(account, first);
+        Assert.Same(account, second);
+        _accountService.Verify(s => s.GetAccountByUsernameAsync("joe"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAccountByUsernameAsync_WhenServiceReturnsNull_DoesNotCache()
+    {
+        var provider = CreateProvider(cacheEnabled: true, out _);
+        _accountService.Setup(s => s.GetAccountByUsernameAsync("ghost")).ReturnsAsync((Account?)null);
+
+        var first = await provider.GetAccountByUsernameAsync("ghost");
+        var second = await provider.GetAccountByUsernameAsync("ghost");
+
+        Assert.Null(first);
+        Assert.Null(second);
+        _accountService.Verify(s => s.GetAccountByUsernameAsync("ghost"), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task GetServersByUserIdAsync_WhenCacheDisabled_CallsService()
+    {
+        var provider = CreateProvider(cacheEnabled: false, out _);
+        var servers = new List<Server> { new(Guid.NewGuid(), "srv", "host.hedgehog.batacek.eu") };
+        _serverService.Setup(s => s.ListServersAsync(100, 0)).ReturnsAsync(servers);
+
+        var result = await provider.GetServersByUserIdAsync(Guid.NewGuid());
+
+        Assert.Single(result);
+        _serverService.Verify(s => s.ListServersAsync(100, 0), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetServersByUserIdAsync_CacheMiss_ThenSecondCallIsServedFromCache()
+    {
+        var provider = CreateProvider(cacheEnabled: true, out _);
+        var userId = Guid.NewGuid();
+        var servers = new List<Server> { new(Guid.NewGuid(), "srv", "host.hedgehog.batacek.eu") };
+        _serverService.Setup(s => s.ListServersAsync(100, 0)).ReturnsAsync(servers);
+
+        await provider.GetServersByUserIdAsync(userId);
+        await provider.GetServersByUserIdAsync(userId);
+
+        _serverService.Verify(s => s.ListServersAsync(100, 0), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetServersByUserIdAsync_WhenCachedServerEvicted_ReloadsFromService()
+    {
+        var provider = CreateProvider(cacheEnabled: true, out var store);
+        var userId = Guid.NewGuid();
+        var server = new Server(Guid.NewGuid(), "srv", "host.hedgehog.batacek.eu");
+        _serverService.Setup(s => s.ListServersAsync(100, 0))
+            .ReturnsAsync(new List<Server> { server });
+
+        await provider.GetServersByUserIdAsync(userId); // caches the relation + server entity
+        store.Remove<Server>(server.Guid);              // evict the entity, keep the relation
+
+        await provider.GetServersByUserIdAsync(userId); // relation present but entity gone -> reload
+
+        _serverService.Verify(s => s.ListServersAsync(100, 0), Times.Exactly(2));
+    }
+
+    [Fact]
+    public void InvalidateAccount_RemovesAccountFromStore()
+    {
+        var provider = CreateProvider(cacheEnabled: true, out var store);
+        var account = new Account(Guid.NewGuid(), "joe", "joe@hedgehog.batacek.eu");
+        store.Set(account.Guid, account);
+
+        provider.InvalidateAccount(account.Guid);
+
+        Assert.Null(store.Get<Account>(account.Guid));
+    }
+
+    [Fact]
+    public void InvalidateServer_RemovesServerFromStore()
+    {
+        var provider = CreateProvider(cacheEnabled: true, out var store);
+        var server = new Server(Guid.NewGuid(), "srv", "host.hedgehog.batacek.eu");
+        store.Set(server.Guid, server);
+
+        provider.InvalidateServer(server.Guid);
+
+        Assert.Null(store.Get<Server>(server.Guid));
+    }
+
+    [Fact]
+    public void InvalidateNode_RemovesNodeFromStore()
+    {
+        var provider = CreateProvider(cacheEnabled: true, out var store);
+        var node = new Node(Guid.NewGuid(), "node", "10.0.0.1", 50051);
+        store.Set(node.Guid, node);
+
+        provider.InvalidateNode(node.Guid);
+
+        Assert.Null(store.Get<Node>(node.Guid));
+    }
+}

--- a/HedgehogPanel.Tests/Unit/Store/InMemoryStoreTests.cs
+++ b/HedgehogPanel.Tests/Unit/Store/InMemoryStoreTests.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Threading.Tasks;
+using HedgehogPanel.Application.Contracts.Logging;
+using HedgehogPanel.Domain.Entities;
+using HedgehogPanel.Infrastructure.Configuration;
+using HedgehogPanel.Infrastructure.Persistence.Store;
+using Moq;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Unit.Store;
+
+public class InMemoryStoreTests
+{
+    private static InMemoryStore CreateStore()
+    {
+        var config = new HedgehogConfig { Cache = new CacheConfig { Enabled = true, TtlMinutes = 0 } };
+        return new InMemoryStore(Mock.Of<ILoggerService>(), config);
+    }
+
+    private static Server NewServer() => new(Guid.NewGuid(), "srv", "host.hedgehog.batacek.eu");
+
+    [Fact]
+    public void Set_ThenGet_ReturnsSameEntity()
+    {
+        var store = CreateStore();
+        var server = NewServer();
+
+        store.Set(server.Guid, server);
+
+        Assert.Same(server, store.Get<Server>(server.Guid));
+    }
+
+    [Fact]
+    public void Get_WhenNotStored_ReturnsNull()
+    {
+        var store = CreateStore();
+        Assert.Null(store.Get<Server>(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Remove_ThenGet_ReturnsNull()
+    {
+        var store = CreateStore();
+        var server = NewServer();
+        store.Set(server.Guid, server);
+
+        store.Remove<Server>(server.Guid);
+
+        Assert.Null(store.Get<Server>(server.Guid));
+    }
+
+    [Fact]
+    public void Get_WithDifferentType_DoesNotReturnEntityOfAnotherType()
+    {
+        var store = CreateStore();
+        var id = Guid.NewGuid();
+        store.Set(id, new Server(id, "srv", "host.hedgehog.batacek.eu"));
+
+        // Same id but a different entity type must not collide.
+        Assert.Null(store.Get<Node>(id));
+    }
+
+    [Fact]
+    public void Set_Twice_OverwritesPreviousValue()
+    {
+        var store = CreateStore();
+        var id = Guid.NewGuid();
+        var first = new Server(id, "first", "host.hedgehog.batacek.eu");
+        var second = new Server(id, "second", "host.hedgehog.batacek.eu");
+
+        store.Set(id, first);
+        store.Set(id, second);
+
+        Assert.Same(second, store.Get<Server>(id));
+    }
+
+    [Fact]
+    public void SetRelation_ThenGetRelation_ReturnsIds()
+    {
+        var store = CreateStore();
+        var ids = new[] { Guid.NewGuid(), Guid.NewGuid() };
+
+        store.SetRelation("rel", ids);
+
+        Assert.Equal(ids, store.GetRelation("rel"));
+    }
+
+    [Fact]
+    public void GetRelation_WhenNotSet_ReturnsEmpty()
+    {
+        var store = CreateStore();
+        Assert.Empty(store.GetRelation("missing"));
+    }
+
+    [Fact]
+    public void RemoveRelation_ThenGetRelation_ReturnsEmpty()
+    {
+        var store = CreateStore();
+        store.SetRelation("rel", new[] { Guid.NewGuid() });
+
+        store.RemoveRelation("rel");
+
+        Assert.Empty(store.GetRelation("rel"));
+    }
+
+    [Fact]
+    public async Task GetOrLoadAsync_WhenNotCached_InvokesLoaderOnceAndCaches()
+    {
+        var store = CreateStore();
+        var server = NewServer();
+        var calls = 0;
+        Task<Server> Loader(Guid _) { calls++; return Task.FromResult(server); }
+
+        var firstResult = await store.GetOrLoadAsync(server.Guid, Loader);
+        var secondResult = await store.GetOrLoadAsync(server.Guid, Loader);
+
+        Assert.Same(server, firstResult);
+        Assert.Same(server, secondResult);
+        Assert.Equal(1, calls); // Second call is served from cache.
+    }
+
+    [Fact]
+    public async Task GetOrLoadAsync_WhenAlreadyCached_DoesNotInvokeLoader()
+    {
+        var store = CreateStore();
+        var server = NewServer();
+        store.Set(server.Guid, server);
+
+        var result = await store.GetOrLoadAsync<Server>(server.Guid,
+            _ => throw new InvalidOperationException("loader must not be called"));
+
+        Assert.Same(server, result);
+    }
+}

--- a/HedgehogPanel.sln
+++ b/HedgehogPanel.sln
@@ -1,6 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HedgehogPanel", "HedgehogPanel\HedgehogPanel.csproj", "{953A9DD2-8474-455A-A9B3-436C1F8B0F64}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HedgehogPanel.Tests", "HedgehogPanel.Tests\HedgehogPanel.Tests.csproj", "{ED1E225D-A054-4EF6-AB15-16CF7D686367}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -12,5 +15,9 @@ Global
 		{953A9DD2-8474-455A-A9B3-436C1F8B0F64}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{953A9DD2-8474-455A-A9B3-436C1F8B0F64}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{953A9DD2-8474-455A-A9B3-436C1F8B0F64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED1E225D-A054-4EF6-AB15-16CF7D686367}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED1E225D-A054-4EF6-AB15-16CF7D686367}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED1E225D-A054-4EF6-AB15-16CF7D686367}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED1E225D-A054-4EF6-AB15-16CF7D686367}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/HedgehogPanel/Infrastructure/Logging/HedgehogLogger.cs
+++ b/HedgehogPanel/Infrastructure/Logging/HedgehogLogger.cs
@@ -34,8 +34,11 @@ public class HedgehogLogger : ILoggerService
     public async Task LogSecurityEventAsync(SecurityEvent securityEvent)
     {
         await _fileLogger.LogSecurityEventAsync(securityEvent);
-
-        await _dbLogger.LogSecurityEventAsync(securityEvent);
+        
+        if (_dbLogger != null)
+        {
+            await _dbLogger.LogSecurityEventAsync(securityEvent);
+        }
     }
 
     public static ILoggerService ForContext<T>() => new HedgehogLogger(typeof(T), _dbLoggerInstance);


### PR DESCRIPTION
Introduces a comprehensive xUnit test suite covering the domain, application, infrastructure, and HTTP layers — **195 tests, all passing**.

### What's included

**Unit tests (mocked dependencies, no I/O)**
- `AuthEndpoints` — JWT generation/verification, time formatting
- `ConfigLoader` — env-var overrides, defaults, connection-string formatting
- `AccountService`, `ServerService`, `AccountLockoutService` — business logic
- Domain entities `Account`, `Server`, `Node`, `Group` — `FullName`/`IsAdmin`, status updates, rename validation, null guards
- `InMemoryStore` — cache hit/miss, type isolation, relations, `GetOrLoadAsync` deduplication
- `DataProvider` — cache passthrough/miss/hit, reload-after-eviction, invalidation

**Integration tests (real PostgreSQL test database)**
- Repositories `AccountRepository`, `ServerRepository`, `NodeRepository` — CRUD, pagination, ownership/assignment, optimistic concurrency (`xmin`), unique-name and group-loading paths
- Endpoints — `auth` (login/logout/me), login input validation, `servers`, `nodes` (CRUD), `admin` (CRUD + role guard) and admin validation
- Cross-cutting security — CSP/hardening headers, JWT bearer auth, CSRF/antiforgery enforcement, per-IP login rate limiting (429), account lockout (423)

**Test infrastructure**
- `PostgreSqlFixture` — creates/seeds/cleans an isolated test database, applies `create.sql`
- `TestDatabaseConfig` — loads DB credentials and the JWT secret from the project `.env`
- `HedgehogWebApplicationFactory` — boots the real app in-memory against the test database
- `EndpointTestSupport`, `TestDataBuilder`, `IntegrationTestsCollection`

### Notable decisions
- **DB config is read from `.env`.** The database name is automatically suffixed with `_test` (e.g. `hedgehogdb` → `hedgehogdb_test`) so the destructive fixture operations (`TRUNCATE`, schema reset) can never touch the production database.
- **`ConfigLoaderTests` joins the `IntegrationTests` collection** so its environment-variable mutations never run in parallel with the booted app, which reads those same variables at startup.
- Antiforgery is stubbed in endpoint tests; the rate-limit and lockout tests use dedicated factory instances so their per-IP counters stay isolated.

### Bug fix included
Fixes a latent `NullReferenceException` in `HedgehogLogger.LogSecurityEventAsync`: the database logger is optional (the constructor allows `null`), but it was dereferenced unconditionally. Database logging is now best-effort and never crashes the request. The new tests surfaced this because the static logger can be bound before `Initialize` runs.