### PR TITLE
feat: structured exception hierarchy and graceful DB error handling

### DIFF
--- a/HedgehogPanel/API/Admin/AdminEndpoints.cs
+++ b/HedgehogPanel/API/Admin/AdminEndpoints.cs
@@ -8,6 +8,7 @@ using HedgehogPanel.Application.Contracts.Logging;
 using HedgehogPanel.Infrastructure.Logging;
 using HedgehogPanel.Infrastructure.Persistence.Store;
 using HedgehogPanel.Infrastructure.Security;
+using HedgehogPanel.Infrastructure.Exceptions;
 using Npgsql;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -121,10 +122,10 @@ public static class AdminEndpoints
                     isAdmin = acc.IsAdmin
                 });
             }
-            catch (PostgresException ex) when (ex.SqlState == "23505") // unique_violation
+            catch (DatabaseConstraintException ex)
             {
-                Logger.Warning(ex, "Unique violation creating user {Username}", req.Username);
-                return Results.Conflict(new { error = "User with the same email already exists." });
+                Logger.Warning(ex, "Constraint violation creating user {Username}", req.Username);
+                return Results.Conflict(new { error = "A user with the same username or email already exists." });
             }
             catch (Exception ex)
             {

--- a/HedgehogPanel/Application/Exceptions/HedgehogException.cs
+++ b/HedgehogPanel/Application/Exceptions/HedgehogException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace HedgehogPanel.Application.Exceptions;
+
+/// <summary>
+/// Base type for every exception deliberately raised by Hedgehog Panel. Catching this type lets
+/// callers distinguish application-defined failures from unexpected framework/runtime exceptions.
+/// </summary>
+public abstract class HedgehogException : Exception
+{
+    protected HedgehogException(string message) : base(message) { }
+    protected HedgehogException(string message, Exception inner) : base(message, inner) { }
+}

--- a/HedgehogPanel/Application/Exceptions/ValidationException.cs
+++ b/HedgehogPanel/Application/Exceptions/ValidationException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace HedgehogPanel.Application.Exceptions;
+
+/// <summary>Raised when input fails an application-level validation rule.</summary>
+public class ValidationException : HedgehogException
+{
+    public ValidationException(string message) : base(message) { }
+    public ValidationException(string message, Exception inner) : base(message, inner) { }
+}

--- a/HedgehogPanel/Domain/Exceptions/DomainException.cs
+++ b/HedgehogPanel/Domain/Exceptions/DomainException.cs
@@ -1,0 +1,11 @@
+using System;
+using HedgehogPanel.Application.Exceptions;
+
+namespace HedgehogPanel.Domain.Exceptions;
+
+/// <summary>Base type for violations of domain rules and invariants.</summary>
+public class DomainException : HedgehogException
+{
+    public DomainException(string message) : base(message) { }
+    public DomainException(string message, Exception inner) : base(message, inner) { }
+}

--- a/HedgehogPanel/Domain/Exceptions/DuplicateEntityException.cs
+++ b/HedgehogPanel/Domain/Exceptions/DuplicateEntityException.cs
@@ -1,0 +1,17 @@
+namespace HedgehogPanel.Domain.Exceptions;
+
+/// <summary>Raised when creating or renaming an entity would violate a uniqueness rule.</summary>
+public class DuplicateEntityException : DomainException
+{
+    public string EntityType { get; }
+    public string Field { get; }
+    public object Value { get; }
+
+    public DuplicateEntityException(string entityType, string field, object value)
+        : base($"{entityType} with {field} '{value}' already exists.")
+    {
+        EntityType = entityType;
+        Field = field;
+        Value = value;
+    }
+}

--- a/HedgehogPanel/Domain/Exceptions/EntityNotFoundException.cs
+++ b/HedgehogPanel/Domain/Exceptions/EntityNotFoundException.cs
@@ -1,0 +1,15 @@
+namespace HedgehogPanel.Domain.Exceptions;
+
+/// <summary>Raised when a requested entity does not exist.</summary>
+public class EntityNotFoundException : DomainException
+{
+    public string EntityType { get; }
+    public object Id { get; }
+
+    public EntityNotFoundException(string entityType, object id)
+        : base($"{entityType} with id '{id}' was not found.")
+    {
+        EntityType = entityType;
+        Id = id;
+    }
+}

--- a/HedgehogPanel/Extensions/HedgehogStartupExtensions.cs
+++ b/HedgehogPanel/Extensions/HedgehogStartupExtensions.cs
@@ -18,6 +18,7 @@ using HedgehogPanel.Infrastructure.Configuration;
 using HedgehogPanel.Infrastructure.Daemon;
 using HedgehogPanel.Infrastructure.Persistence.Store;
 using HedgehogPanel.Infrastructure.Security;
+using HedgehogPanel.Infrastructure.Exceptions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
@@ -297,24 +298,34 @@ public static class HedgehogStartupExtensions
             app.UseCors();
         }
 
-        if (!app.Environment.IsDevelopment())
+        app.UseExceptionHandler(errApp =>
         {
-            app.UseExceptionHandler(errApp =>
+            errApp.Run(async context =>
             {
-                errApp.Run(async context =>
+                var error = context.Features.Get<IExceptionHandlerFeature>()?.Error;
+
+                var (statusCode, message) = error switch
                 {
-                    context.Response.StatusCode = StatusCodes.Status500InternalServerError;
-                    context.Response.ContentType = "application/json";
-                    var problem = new
-                    {
-                        title = "An error occurred while processing your request.",
-                        status = 500,
-                        traceId = context.TraceIdentifier
-                    };
-                    await context.Response.WriteAsJsonAsync(problem);
-                });
+                    DatabaseConnectionException => (
+                        StatusCodes.Status503ServiceUnavailable,
+                        "The service is temporarily unavailable. Please try again later."),
+                    _ => (
+                        StatusCodes.Status500InternalServerError,
+                        "An error occurred while processing your request.")
+                };
+                
+                logger.Error(error!, "Unhandled exception for {Method} {Path} -> {StatusCode}.",
+                    context.Request.Method, context.Request.Path, statusCode);
+
+                context.Response.StatusCode = statusCode;
+                if (statusCode == StatusCodes.Status503ServiceUnavailable)
+                {
+                    context.Response.Headers["Retry-After"] = "30";
+                }
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsJsonAsync(new { error = message, status = statusCode });
             });
-        }
+        });
 
         app.UseRateLimiter();
         app.UseAuthentication();

--- a/HedgehogPanel/Infrastructure/Exceptions/DatabaseConnectionException.cs
+++ b/HedgehogPanel/Infrastructure/Exceptions/DatabaseConnectionException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace HedgehogPanel.Infrastructure.Exceptions;
+
+/// <summary>Raised when a connection to the database cannot be established.</summary>
+public class DatabaseConnectionException : DatabaseException
+{
+    public DatabaseConnectionException(string host, Exception inner)
+        : base($"Could not connect to the database at '{host}'.", inner) { }
+}

--- a/HedgehogPanel/Infrastructure/Exceptions/DatabaseConstraintException.cs
+++ b/HedgehogPanel/Infrastructure/Exceptions/DatabaseConstraintException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace HedgehogPanel.Infrastructure.Exceptions;
+
+/// <summary>Raised when a database constraint (e.g. a unique index) is violated.</summary>
+public class DatabaseConstraintException : DatabaseException
+{
+    public string ConstraintName { get; }
+
+    public DatabaseConstraintException(string constraintName, Exception inner)
+        : base($"A database constraint was violated: '{constraintName}'.", inner)
+    {
+        ConstraintName = constraintName;
+    }
+}

--- a/HedgehogPanel/Infrastructure/Exceptions/DatabaseException.cs
+++ b/HedgehogPanel/Infrastructure/Exceptions/DatabaseException.cs
@@ -1,0 +1,14 @@
+using System;
+using HedgehogPanel.Application.Exceptions;
+
+namespace HedgehogPanel.Infrastructure.Exceptions;
+
+/// <summary>
+/// Represents a failure originating from the database/persistence layer. Concrete Npgsql
+/// exceptions are translated into this type (or a subtype) so they never leak above Infrastructure.
+/// </summary>
+public class DatabaseException : HedgehogException
+{
+    public DatabaseException(string message) : base(message) { }
+    public DatabaseException(string message, Exception inner) : base(message, inner) { }
+}

--- a/HedgehogPanel/Infrastructure/Exceptions/DbExceptionGuard.cs
+++ b/HedgehogPanel/Infrastructure/Exceptions/DbExceptionGuard.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using Npgsql;
+
+namespace HedgehogPanel.Infrastructure.Exceptions;
+
+/// <summary>
+/// Runs a database operation and translates Npgsql-specific exceptions into Hedgehog's typed
+/// database exceptions, so Npgsql types never leak out of the Infrastructure layer.
+/// </summary>
+internal static class DbExceptionGuard
+{
+    public static async Task<T> ExecuteAsync<T>(Func<Task<T>> operation)
+    {
+        try
+        {
+            return await operation();
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UniqueViolation)
+        {
+            throw new DatabaseConstraintException(ex.ConstraintName ?? ex.SqlState, ex);
+        }
+        catch (PostgresException ex)
+        {
+            throw new DatabaseException($"Database query failed (SQL state {ex.SqlState}).", ex);
+        }
+        catch (NpgsqlException ex)
+        {
+            throw new DatabaseException("A database error occurred.", ex);
+        }
+    }
+}

--- a/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/NpgsqlConnectionFactory.cs
+++ b/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/NpgsqlConnectionFactory.cs
@@ -3,29 +3,48 @@ using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 using HedgehogPanel.Application.Persistence;
+using HedgehogPanel.Infrastructure.Exceptions;
 using Npgsql;
 
 namespace HedgehogPanel.Infrastructure.Persistence.PostgreSQL;
 
 /// <summary>
 /// A factory class for creating PostgreSQL database connections using NpgsqlDataSource.
+/// Connection failures are translated into <see cref="DatabaseConnectionException"/> so callers
+/// never see raw Npgsql exceptions.
 /// </summary>
 public class NpgsqlConnectionFactory : IDbConnectionFactory
 {
     private readonly NpgsqlDataSource _dataSource;
+    private readonly string _host;
 
     public NpgsqlConnectionFactory(NpgsqlDataSource dataSource)
     {
         _dataSource = dataSource ?? throw new ArgumentNullException(nameof(dataSource));
+        _host = new NpgsqlConnectionStringBuilder(dataSource.ConnectionString).Host ?? "unknown";
     }
 
     public IDbConnection CreateConnection()
     {
-        return _dataSource.CreateConnection();
+        try
+        {
+            return _dataSource.CreateConnection();
+        }
+        catch (NpgsqlException ex)
+        {
+            throw new DatabaseConnectionException(_host, ex);
+        }
     }
 
     public async ValueTask<IDbConnection> CreateConnectionAsync(CancellationToken cancellationToken = default)
     {
-        return await _dataSource.OpenConnectionAsync(cancellationToken);
+        try
+        {
+            return await _dataSource.OpenConnectionAsync(cancellationToken);
+        }
+        catch (NpgsqlException ex)
+        {
+            throw new DatabaseConnectionException(_host, ex);
+        }
     }
 }

--- a/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/Repositories/AccountRepository.cs
+++ b/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/Repositories/AccountRepository.cs
@@ -7,6 +7,7 @@ using HedgehogPanel.Application.Repositories;
 using HedgehogPanel.Application.Persistence;
 using HedgehogPanel.Domain.Entities;
 using Npgsql;
+using HedgehogPanel.Infrastructure.Exceptions;
 
 namespace HedgehogPanel.Infrastructure.Persistence.PostgreSQL.Repositories;
 
@@ -34,7 +35,7 @@ public class AccountRepository : IAccountRepository
         await using (var cmd = new NpgsqlCommand(sql, npgsqlConn))
         {
             cmd.Parameters.AddWithValue("@id", guid);
-            await using (var reader = await cmd.ExecuteReaderAsync())
+            await using (var reader = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteReaderAsync()))
             {
                 if (!await reader.ReadAsync()) return null;
                 
@@ -67,7 +68,7 @@ public class AccountRepository : IAccountRepository
         await using (var cmd = new NpgsqlCommand(sql, npgsqlConn))
         {
             cmd.Parameters.AddWithValue("@u", username);
-            await using (var reader = await cmd.ExecuteReaderAsync())
+            await using (var reader = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteReaderAsync()))
             {
                 if (!await reader.ReadAsync()) return null;
                 
@@ -99,7 +100,7 @@ public class AccountRepository : IAccountRepository
         var accounts = new List<Account>();
         var userDatas = new List<(Guid guid, string uname, string email, string? first, string? middle, string? last, uint xmin)>();
         
-        await using (var reader = await cmd.ExecuteReaderAsync())
+        await using (var reader = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteReaderAsync()))
         {
             while (await reader.ReadAsync())
             {
@@ -140,7 +141,7 @@ public class AccountRepository : IAccountRepository
          cmd.Parameters.AddWithValue("@m", (object?)account.MiddleName ?? DBNull.Value);
          cmd.Parameters.AddWithValue("@l", (object?)account.LastName ?? DBNull.Value);
 
-         return await cmd.ExecuteNonQueryAsync() > 0;
+         return await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteNonQueryAsync()) > 0;
     }
 
     public async Task<bool> UpdateAsync(Account account, string? newPasswordHash = null)
@@ -164,7 +165,7 @@ public class AccountRepository : IAccountRepository
         if (newPasswordHash != null) cmd.Parameters.AddWithValue("@p", newPasswordHash);
         if (account.RowVersion > 0) cmd.Parameters.AddWithValue("@v", (int)account.RowVersion);
 
-        return await cmd.ExecuteNonQueryAsync() > 0;
+        return await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteNonQueryAsync()) > 0;
     }
 
     public async Task<bool> DeleteAsync(Guid guid)
@@ -175,7 +176,7 @@ public class AccountRepository : IAccountRepository
         const string sql = "DELETE FROM users WHERE uuid = @id";
         await using var cmd = new NpgsqlCommand(sql, npgsqlConn);
         cmd.Parameters.AddWithValue("@id", guid);
-        return await cmd.ExecuteNonQueryAsync() > 0;
+        return await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteNonQueryAsync()) > 0;
     }
     
     // Pomocná metoda pro autentizaci, protože hashování je v DB
@@ -199,7 +200,7 @@ public class AccountRepository : IAccountRepository
         {
             cmd.Parameters.AddWithValue("@u", username);
             cmd.Parameters.AddWithValue("@p", password);
-            await using (var reader = await cmd.ExecuteReaderAsync())
+            await using (var reader = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteReaderAsync()))
             {
                 if (!await reader.ReadAsync()) return null;
 
@@ -227,7 +228,7 @@ public class AccountRepository : IAccountRepository
         await using var cmd = new NpgsqlCommand(sql, connection);
         cmd.Parameters.AddWithValue("@id", userGuid);
         var groups = new List<Group>();
-        await using (var reader = await cmd.ExecuteReaderAsync())
+        await using (var reader = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteReaderAsync()))
         {
             while (await reader.ReadAsync())
             {

--- a/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/Repositories/NodeRepository.cs
+++ b/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/Repositories/NodeRepository.cs
@@ -8,6 +8,8 @@ using HedgehogPanel.Domain.Entities;
 using HedgehogPanel.Infrastructure.Configuration;
 using HedgehogPanel.Infrastructure.Persistence.Store;
 using Npgsql;
+using HedgehogPanel.Domain.Exceptions;
+using HedgehogPanel.Infrastructure.Exceptions;
 
 namespace HedgehogPanel.Infrastructure.Persistence.PostgreSQL.Repositories;
 
@@ -38,7 +40,7 @@ public class NodeRepository : INodeRepository
         const string sql = "SELECT uuid, name, ip_address, port, description, status, registration_token, last_seen, created_at FROM nodes WHERE uuid = @id LIMIT 1";
         await using var cmd = new NpgsqlCommand(sql, npgsqlConn);
         cmd.Parameters.AddWithValue("@id", guid);
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteReaderAsync());
         if (!await reader.ReadAsync()) return null;
 
         var node = MapNode(reader);
@@ -86,7 +88,7 @@ public class NodeRepository : INodeRepository
         cmd.Parameters.AddWithValue("@offset", offset);
         
         var list = new List<Node>();
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteReaderAsync());
         while (await reader.ReadAsync())
         {
             var node = MapNode(reader);
@@ -116,10 +118,10 @@ public class NodeRepository : INodeRepository
         const string checkSql = @"SELECT EXISTS(SELECT 1 FROM nodes WHERE name = @name)";
         await using var checkCmd = new NpgsqlCommand(checkSql, npgsqlConn);
         checkCmd.Parameters.AddWithValue("@name", node.Name);
-        var existsObj = await checkCmd.ExecuteScalarAsync();
+        var existsObj = await DbExceptionGuard.ExecuteAsync(() => checkCmd.ExecuteScalarAsync());
         if (existsObj != null && (bool)existsObj)
         {
-            throw new InvalidOperationException($"Node with name '{node.Name}' already exists.");
+            throw new DuplicateEntityException("Node", "name", node.Name);
         }
 
         const string sql = "INSERT INTO nodes (uuid, name, ip_address, port, description, status, registration_token, last_seen) VALUES (@id, @name, @ip, @port, @desc, @status, @token, @lastSeen)";
@@ -133,7 +135,7 @@ public class NodeRepository : INodeRepository
         cmd.Parameters.AddWithValue("@token", (object?)node.RegistrationToken ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@lastSeen", (object?)node.LastSeen ?? DBNull.Value);
 
-        var result = await cmd.ExecuteNonQueryAsync() > 0;
+        var result = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteNonQueryAsync()) > 0;
         
         if (result && _config.Cache.Enabled)
         {
@@ -153,10 +155,10 @@ public class NodeRepository : INodeRepository
         const string checkSql = @"SELECT EXISTS(SELECT 1 FROM nodes WHERE name = @name)";
         await using var checkCmd = new NpgsqlCommand(checkSql, npgsqlConn);
         checkCmd.Parameters.AddWithValue("@name", node.Name);
-        var existsObj = await checkCmd.ExecuteScalarAsync();
+        var existsObj = await DbExceptionGuard.ExecuteAsync(() => checkCmd.ExecuteScalarAsync());
         if (existsObj != null && (bool)existsObj)
         {
-            throw new InvalidOperationException($"Node with name '{node.Name}' already exists.");
+            throw new DuplicateEntityException("Node", "name", node.Name);
         }
         
         const string sql = "UPDATE nodes SET name = @name, ip_address = @ip, port = @port, description = @desc, status = @status, registration_token = @token, last_seen = @lastSeen WHERE uuid = @id";
@@ -170,7 +172,7 @@ public class NodeRepository : INodeRepository
         cmd.Parameters.AddWithValue("@lastSeen", (object?)node.LastSeen ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@id", node.Guid);
 
-        var result = await cmd.ExecuteNonQueryAsync() > 0;
+        var result = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteNonQueryAsync()) > 0;
         
         if (result && _config.Cache.Enabled)
         {
@@ -190,7 +192,7 @@ public class NodeRepository : INodeRepository
         const string sql = "DELETE FROM nodes WHERE uuid = @id";
         await using var cmd = new NpgsqlCommand(sql, npgsqlConn);
         cmd.Parameters.AddWithValue("@id", guid);
-        var result = await cmd.ExecuteNonQueryAsync() > 0;
+        var result = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteNonQueryAsync()) > 0;
         
         if (result && _config.Cache.Enabled)
         {

--- a/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/Repositories/ServerRepository.cs
+++ b/HedgehogPanel/Infrastructure/Persistence/PostgreSQL/Repositories/ServerRepository.cs
@@ -5,6 +5,7 @@ using HedgehogPanel.Application.Repositories;
 using HedgehogPanel.Application.Persistence;
 using HedgehogPanel.Domain.Entities;
 using Npgsql;
+using HedgehogPanel.Infrastructure.Exceptions;
 
 namespace HedgehogPanel.Infrastructure.Persistence.PostgreSQL.Repositories;
 
@@ -25,7 +26,7 @@ public class ServerRepository : IServerRepository
         const string sql = "SELECT uuid, name, hostname, daemon_port, description, created_at FROM servers WHERE uuid = @id LIMIT 1";
         await using var cmd = new NpgsqlCommand(sql, npgsqlConn);
         cmd.Parameters.AddWithValue("@id", guid);
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteReaderAsync());
         if (!await reader.ReadAsync()) return null;
 
         return MapServer(reader);
@@ -42,7 +43,7 @@ public class ServerRepository : IServerRepository
         cmd.Parameters.AddWithValue("@offset", offset);
         
         var list = new List<Server>();
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteReaderAsync());
         while (await reader.ReadAsync())
         {
             list.Add(MapServer(reader));
@@ -63,7 +64,7 @@ public class ServerRepository : IServerRepository
         cmd.Parameters.AddWithValue("@h", server.Hostname);
         cmd.Parameters.AddWithValue("@p", server.DaemonPort);
 
-        return await cmd.ExecuteNonQueryAsync() > 0;
+        return await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteNonQueryAsync()) > 0;
     }
 
     public async Task<bool> UpdateAsync(Server server)
@@ -79,7 +80,7 @@ public class ServerRepository : IServerRepository
         cmd.Parameters.AddWithValue("@d", (object?)server.Description ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@id", server.Guid);
 
-        return await cmd.ExecuteNonQueryAsync() > 0;
+        return await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteNonQueryAsync()) > 0;
     }
 
     public async Task<bool> DeleteAsync(Guid guid)
@@ -90,7 +91,7 @@ public class ServerRepository : IServerRepository
         const string sql = "DELETE FROM servers WHERE uuid = @id";
         await using var cmd = new NpgsqlCommand(sql, npgsqlConn);
         cmd.Parameters.AddWithValue("@id", guid);
-        return await cmd.ExecuteNonQueryAsync() > 0;
+        return await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteNonQueryAsync()) > 0;
     }
 
     public async Task<IReadOnlyList<Server>> ListByOwnerAsync(Guid userGuid, int limit, int offset)
@@ -112,7 +113,7 @@ public class ServerRepository : IServerRepository
         cmd.Parameters.AddWithValue("@offset", offset);
         
         var list = new List<Server>();
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteReaderAsync());
         while (await reader.ReadAsync())
         {
             list.Add(MapServer(reader));
@@ -138,7 +139,7 @@ public class ServerRepository : IServerRepository
         cmd.Parameters.AddWithValue("@offset", offset);
         
         var list = new List<Server>();
-        await using var reader = await cmd.ExecuteReaderAsync();
+        await using var reader = await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteReaderAsync());
         while (await reader.ReadAsync())
         {
             list.Add(MapServer(reader));
@@ -161,7 +162,7 @@ public class ServerRepository : IServerRepository
         await using var cmd = new NpgsqlCommand(sql, npgsqlConn);
         cmd.Parameters.AddWithValue("@serverGuid", serverGuid);
         
-        return (string?)await cmd.ExecuteScalarAsync();
+        return (string?)await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteScalarAsync());
     }
 
     public async Task<bool> AssignToUserAsync(Guid serverGuid, Guid userGuid)
@@ -173,7 +174,7 @@ public class ServerRepository : IServerRepository
         const string checkSql = "SELECT EXISTS(SELECT 1 FROM servers WHERE uuid = @serverGuid)";
         await using var checkCmd = new NpgsqlCommand(checkSql, npgsqlConn);
         checkCmd.Parameters.AddWithValue("@serverGuid", serverGuid);
-        var existsObj = await checkCmd.ExecuteScalarAsync();
+        var existsObj = await DbExceptionGuard.ExecuteAsync(() => checkCmd.ExecuteScalarAsync());
         if (!(bool)(existsObj ?? false)) return false;
 
         const string sql = @"
@@ -185,7 +186,7 @@ public class ServerRepository : IServerRepository
         cmd.Parameters.AddWithValue("@serverGuid", serverGuid);
         cmd.Parameters.AddWithValue("@userGuid", userGuid);
         
-        return await cmd.ExecuteNonQueryAsync() > 0;
+        return await DbExceptionGuard.ExecuteAsync(() => cmd.ExecuteNonQueryAsync()) > 0;
     }
 
     private Server MapServer(NpgsqlDataReader reader)


### PR DESCRIPTION
## Summary

Implements a structured exception hierarchy to isolate Npgsql from upper layers and prevent raw stack traces from leaking to the browser.

**Problem:** When PostgreSQL was offline, the full `NpgsqlException` stack trace (including DB host and port) was rendered in the browser via ASP.NET's developer exception page — in all environments. This exposed internal infrastructure details.

**Solution:** Three-part fix:

- **New exception hierarchy** (`HedgehogException` → domain/application/infrastructure subtypes) so Npgsql types never propagate above the Infrastructure layer
- **`DbExceptionGuard.ExecuteAsync()`** — central Npgsql-to-typed-exception translator used by all repositories on every `ExecuteReader`/`ExecuteNonQuery`/`ExecuteScalar` call
- **Global exception handler** (`UseExceptionHandler`) now active in **all environments** (was previously skipped in Development), returning clean JSON with no stack trace or internal details

## Changes

### New files — exception types

- `Application/Exceptions/HedgehogException.cs` — root base class
- `Application/Exceptions/ValidationException.cs` — application-level validation failures
- `Domain/Exceptions/DomainException.cs` — domain rule violations base
- `Domain/Exceptions/EntityNotFoundException.cs` — 404 semantic (entity type + id)
- `Domain/Exceptions/DuplicateEntityException.cs` — 409 semantic (entity type + field + value)
- `Infrastructure/Exceptions/DatabaseException.cs` — generic DB failure base
- `Infrastructure/Exceptions/DatabaseConnectionException.cs` — connection-level failures (host context)
- `Infrastructure/Exceptions/DatabaseConstraintException.cs` — unique/FK constraint violations (constraint name)
- `Infrastructure/Exceptions/DbExceptionGuard.cs` — wraps `PostgresException`/`NpgsqlException` → typed exceptions

### Modified files

- `NpgsqlConnectionFactory.cs` — wraps failed `OpenConnectionAsync` → `DatabaseConnectionException(_host, ex)`
- `AccountRepository.cs` — all `Execute*` calls wrapped in `DbExceptionGuard.ExecuteAsync()`
- `ServerRepository.cs` — same
- `NodeRepository.cs` — same; `InvalidOperationException` for duplicate name → `DuplicateEntityException`
- `AdminEndpoints.cs` — catches `DatabaseConstraintException` instead of raw `PostgresException`
- `HedgehogStartupExtensions.cs` — exception handler runs unconditionally; maps `DatabaseConnectionException` → 503 + `Retry-After: 30`, others → 500; logs full exception server-side only

## Behavior after this PR

| Scenario | Before | After |
|---|---|---|
| DB offline (any env) | Full Npgsql stack trace in browser | `{"error":"The service is temporarily unavailable...","status":503}` + `Retry-After: 30` |
| Unique constraint violation | Raw `PostgresException` | `409 Conflict` with user-friendly message |
| Any unhandled exception | Leaked in Development | Clean JSON 500, full details in Serilog log only |
