### PR TITLE
Harden account lockout: fix double-count, add account-global throttle, make the policy runtime-configurable

### DIFF
--- a/HedgehogPanel.Tests/Integration/Endpoints/LoginFailureCountTests.cs
+++ b/HedgehogPanel.Tests/Integration/Endpoints/LoginFailureCountTests.cs
@@ -1,0 +1,50 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using HedgehogPanel.Tests.Integration.TestFixtures;
+using Xunit;
+
+namespace HedgehogPanel.Tests.Integration.Endpoints;
+
+/// <summary>
+/// Regression test for the failed-attempt double-count bug: a single wrong password must increment
+/// the lockout counter by exactly one, so the account locks only on the fifth failure (not the third).
+/// Uses a dedicated factory so its rate-limit/lockout partition is isolated from other suites.
+/// </summary>
+[Collection("IntegrationTests")]
+public class LoginFailureCountTests : IClassFixture<LoginFailureCountTests.FailureCountFactory>
+{
+    private readonly PostgreSqlFixture _db;
+    private readonly FailureCountFactory _factory;
+
+    public LoginFailureCountTests(PostgreSqlFixture db, FailureCountFactory factory)
+    {
+        _db = db;
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task WrongPassword_IncrementsCounterByExactlyOne_LockingOnTheFifthAttempt()
+    {
+        await _db.CleanDatabaseAsync();
+        var user = await EndpointTestSupport.SeedUserAsync(_db.ConnectionString, "double_count");
+        var client = EndpointTestSupport.NewClient(_factory);
+
+        for (var attempt = 1; attempt <= 4; attempt++)
+        {
+            var failed = await client.PostAsJsonAsync("/api/login",
+                new { username = user.Username, password = "definitely-wrong" });
+            Assert.Equal(HttpStatusCode.Unauthorized, failed.StatusCode);
+        }
+
+        var fifth = await client.PostAsJsonAsync("/api/login",
+            new { username = user.Username, password = "definitely-wrong" });
+        Assert.Equal(HttpStatusCode.Locked, fifth.StatusCode);
+    }
+
+    /// <summary>Dedicated factory so this class has its own lockout/rate-limit partition.</summary>
+    public sealed class FailureCountFactory : HedgehogWebApplicationFactory
+    {
+    }
+}

--- a/HedgehogPanel.Tests/Unit/Services/AccountLockoutServiceTests.cs
+++ b/HedgehogPanel.Tests/Unit/Services/AccountLockoutServiceTests.cs
@@ -15,7 +15,7 @@ public class AccountLockoutServiceTests
     public AccountLockoutServiceTests()
     {
         _mockCache = new Mock<IMemoryCache>();
-        _service = new AccountLockoutService(_mockCache.Object);
+        _service = new AccountLockoutService(_mockCache.Object, new LockoutSettings());
     }
 
     [Fact]
@@ -158,13 +158,13 @@ public class AccountLockoutServiceTests
     }
 
     [Fact]
-    public async Task UnlockAccountAsync_RemovesCacheEntry()
+    public async Task UnlockAccountAsync_RemovesBothPerIpAndGlobalEntries()
     {
         // Arrange & Act
         await _service.UnlockAccountAsync("testuser", "127.0.0.1");
 
-        // Assert
-        _mockCache.Verify(c => c.Remove(It.IsAny<object>()), Times.Once);
+        // Assert - admin unlock clears the per-IP counter and the account-global counter.
+        _mockCache.Verify(c => c.Remove(It.IsAny<object>()), Times.Exactly(2));
     }
 
     [Fact]
@@ -191,6 +191,66 @@ public class AccountLockoutServiceTests
         // Assert - should not be locked because old attempts are cleaned up
         var lockedUntil = lockoutInfo.GetType().GetProperty("LockedUntil")!.GetValue(lockoutInfo) as DateTimeOffset?;
         Assert.Null(lockedUntil);
+    }
+
+    // ----- Account-global throttle (exercised against a real in-memory cache) -----
+
+    private static AccountLockoutService RealService() =>
+        new(new MemoryCache(new MemoryCacheOptions()), new LockoutSettings());
+
+    [Fact]
+    public async Task PerIp_FourFailures_DoesNotLockThatClient()
+    {
+        var service = RealService();
+        for (var i = 0; i < 4; i++)
+        {
+            await service.RecordFailedAttemptAsync("targetuser", "10.0.0.1");
+        }
+
+        Assert.False(await service.IsAccountLockedAsync("targetuser", "10.0.0.1"));
+    }
+
+    [Fact]
+    public async Task PerIp_FifthFailure_LocksOnlyThatClient()
+    {
+        var service = RealService();
+        for (var i = 0; i < 5; i++)
+        {
+            await service.RecordFailedAttemptAsync("targetuser", "10.0.0.1");
+        }
+
+        // The offending client is locked, but the account-global ceiling (15) is not yet reached,
+        // so a different source IP still gets a fresh budget.
+        Assert.True(await service.IsAccountLockedAsync("targetuser", "10.0.0.1"));
+        Assert.False(await service.IsAccountLockedAsync("targetuser", "10.0.0.2"));
+    }
+
+    [Fact]
+    public async Task AccountGlobal_ManyDistinctIps_LockEvenFromAFreshIp()
+    {
+        var service = RealService();
+
+        // 15 single failures, each from a different IP - none trips the per-IP limit (5),
+        // but together they reach the account-global ceiling (15).
+        for (var i = 0; i < 15; i++)
+        {
+            await service.RecordFailedAttemptAsync("targetuser", $"192.0.2.{i}");
+        }
+
+        // A source IP that never failed is throttled because the account is globally locked.
+        Assert.True(await service.IsAccountLockedAsync("targetuser", "203.0.113.99"));
+    }
+
+    [Fact]
+    public async Task AccountGlobal_DoesNotAffectOtherAccounts()
+    {
+        var service = RealService();
+        for (var i = 0; i < 15; i++)
+        {
+            await service.RecordFailedAttemptAsync("targetuser", $"192.0.2.{i}");
+        }
+
+        Assert.False(await service.IsAccountLockedAsync("bystander", "203.0.113.99"));
     }
 
     private object CreateLockoutInfo()

--- a/HedgehogPanel/API/Admin/AdminEndpoints.cs
+++ b/HedgehogPanel/API/Admin/AdminEndpoints.cs
@@ -247,6 +247,42 @@ public static class AdminEndpoints
             return ok ? Results.Ok(new { success = true }) : Results.NotFound(new { error = "Server not found." });
         }).RequireAuthorization();;
 
+        group.MapGet("/settings/lockout", (ILockoutSettings settings) =>
+            Results.Ok(new
+            {
+                maxFailedAttempts = settings.MaxFailedAttempts,
+                lockoutMinutes = (int)settings.LockoutDuration.TotalMinutes
+            })).RequireAuthorization();
+
+        group.MapPut("/settings/lockout", async (HttpContext ctx, UpdateLockoutSettingsRequest req, ILockoutSettings settings) =>
+        {
+            if (req is null) return Results.BadRequest(new { error = "Request body is required." });
+            if (req.MaxFailedAttempts < 1 || req.MaxFailedAttempts > 100)
+                return Results.BadRequest(new { error = "Max failed attempts must be between 1 and 100." });
+            if (req.LockoutMinutes < 1 || req.LockoutMinutes > 1440)
+                return Results.BadRequest(new { error = "Lockout duration must be between 1 and 1440 minutes." });
+
+            settings.Update(req.MaxFailedAttempts, req.LockoutMinutes);
+
+            var ip = ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            var actorGuidClaim = ctx.User?.FindFirst("guid")?.Value;
+            Guid? actorGuid = actorGuidClaim != null ? Guid.Parse(actorGuidClaim) : null;
+            await Logger.LogSecurityEventAsync(new SecurityEvent(
+                "Security.LockoutSettingsUpdated",
+                null,
+                actorGuid,
+                ip,
+                ctx.Request.Headers["User-Agent"],
+                true,
+                new { req.MaxFailedAttempts, req.LockoutMinutes }));
+
+            return Results.Ok(new
+            {
+                maxFailedAttempts = settings.MaxFailedAttempts,
+                lockoutMinutes = (int)settings.LockoutDuration.TotalMinutes
+            });
+        }).RequireAuthorization();
+
         Logger.Information("Admin endpoints mapped.");
         return endpoints;
     }
@@ -254,4 +290,5 @@ public static class AdminEndpoints
     public record CreateUserRequest(string Username, string Email, string Password, string? FirstName, string? MiddleName, string? LastName);
     public record CreateServerRequest(string Name, string? Description, string? OwnerUsername);
     public record UnlockUserRequest(string ClientIp);
+    public record UpdateLockoutSettingsRequest(int MaxFailedAttempts, int LockoutMinutes);
 }

--- a/HedgehogPanel/API/Auth/AuthEndpoints.cs
+++ b/HedgehogPanel/API/Auth/AuthEndpoints.cs
@@ -76,8 +76,6 @@ public static class AuthEndpoints
                 var account = await accountService.AuthenticateAsync(username, password);
                 if (account == null)
                 {
-                    await lockoutSvc.RecordFailedAttemptAsync(username, ip);
-                    Logger.Warning("Authentication failed for user {Username} from {IP}.", username, ip);
                     throw new UnauthorizedAccessException("Invalid username or password.");
                 }
                 

--- a/HedgehogPanel/Extensions/HedgehogStartupExtensions.cs
+++ b/HedgehogPanel/Extensions/HedgehogStartupExtensions.cs
@@ -182,6 +182,7 @@ public static class HedgehogStartupExtensions
         });
 
         builder.Services.AddMemoryCache();
+        builder.Services.AddSingleton<ILockoutSettings, LockoutSettings>();
         builder.Services.AddScoped<IAccountLockoutService, AccountLockoutService>();
 
         logger.Information("Setting up authentication and authorization...");

--- a/HedgehogPanel/Infrastructure/Security/AccountLockoutService.cs
+++ b/HedgehogPanel/Infrastructure/Security/AccountLockoutService.cs
@@ -12,18 +12,21 @@ public class AccountLockoutService : IAccountLockoutService
 {
     private static readonly ILoggerService Logger = HedgehogLogger.ForContext(typeof(AccountLockoutService));
 
-    private const int MaxFailedAttempts = 5;
     private static readonly TimeSpan FailedAttemptsWindow = TimeSpan.FromMinutes(15);
-    private static readonly TimeSpan LockoutDuration = TimeSpan.FromMinutes(5);
+    private const int MaxGlobalFailedAttempts = 15;
+    private static readonly TimeSpan GlobalLockoutDuration = TimeSpan.FromMinutes(15);
 
     private readonly IMemoryCache _cache;
+    private readonly ILockoutSettings _settings;
 
-    public AccountLockoutService(IMemoryCache cache)
+    public AccountLockoutService(IMemoryCache cache, ILockoutSettings settings)
     {
         _cache = cache;
+        _settings = settings;
     }
 
-    private static string Key(string username, string clientIp) => $"lockout:{username?.ToLowerInvariant()}|{clientIp}";
+    private static string PerIpKey(string username, string clientIp) => $"lockout:{username?.ToLowerInvariant()}|{clientIp}";
+    private static string GlobalKey(string username) => $"lockout-global:{username?.ToLowerInvariant()}";
 
     private class LockoutInfo
     {
@@ -33,27 +36,80 @@ public class AccountLockoutService : IAccountLockoutService
 
     public Task<bool> IsAccountLockedAsync(string username, string clientIp)
     {
-        var info = GetInfo(username, clientIp);
-        CleanupWindow(info);
-        var locked = info.LockedUntil != null && info.LockedUntil > DateTimeOffset.UtcNow;
+        var lockedUntil = MaxRemainingLockout(username, clientIp);
+        var locked = lockedUntil != null && lockedUntil > DateTimeOffset.UtcNow;
         if (locked)
         {
-            var remaining = info.LockedUntil!.Value - DateTimeOffset.UtcNow;
-            Logger.Information("Account {Username} from {IP} is locked. Remaining {Remaining}.", username, clientIp, remaining);
+            Logger.Information("Account {Username} from {IP} is locked. Remaining {Remaining}.", username, clientIp, lockedUntil!.Value - DateTimeOffset.UtcNow);
         }
         return Task.FromResult(locked);
     }
 
     public Task RecordFailedAttemptAsync(string username, string clientIp)
     {
-        var info = GetInfo(username, clientIp);
+        RecordInBucket(PerIpKey(username, clientIp), _settings.MaxFailedAttempts, _settings.LockoutDuration, username, clientIp, isGlobal: false);
+        RecordInBucket(GlobalKey(username), MaxGlobalFailedAttempts, GlobalLockoutDuration, username, clientIp, isGlobal: true);
+        return Task.CompletedTask;
+    }
+
+    public Task ResetFailedAttemptsAsync(string username, string clientIp)
+    {
+        _cache.Remove(PerIpKey(username, clientIp));
+        Logger.Information("Reset lockout counters for {Username} from {IP} after successful login.", username, clientIp);
+        return Task.CompletedTask;
+    }
+
+    public Task<TimeSpan?> GetLockoutTimeRemainingAsync(string username, string clientIp)
+    {
+        var until = MaxRemainingLockout(username, clientIp);
+        if (until is { } value && value > DateTimeOffset.UtcNow)
+        {
+            return Task.FromResult<TimeSpan?>(value - DateTimeOffset.UtcNow);
+        }
+        return Task.FromResult<TimeSpan?>(null);
+    }
+
+    public Task UnlockAccountAsync(string username, string clientIp)
+    {
+        _cache.Remove(PerIpKey(username, clientIp));
+        _cache.Remove(GlobalKey(username));
+        Logger.Information("Manually unlocked account {Username} from {IP} by admin.", username, clientIp);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Returns the later of the per-IP and account-global lockout expiries, or null if neither is locked.</summary>
+    private DateTimeOffset? MaxRemainingLockout(string username, string clientIp)
+    {
+        var perIp = LockedUntil(PerIpKey(username, clientIp));
+        var global = LockedUntil(GlobalKey(username));
+        if (perIp == null) return global;
+        if (global == null) return perIp;
+        return perIp > global ? perIp : global;
+    }
+
+    private DateTimeOffset? LockedUntil(string key)
+    {
+        var info = GetInfo(key);
+        CleanupWindow(info);
+        if (info.LockedUntil is { } until && until > DateTimeOffset.UtcNow)
+        {
+            return until;
+        }
+        return null;
+    }
+
+    private void RecordInBucket(string key, int threshold, TimeSpan lockoutDuration, string username, string clientIp, bool isGlobal)
+    {
+        var info = GetInfo(key);
         CleanupWindow(info);
         info.FailedTimestamps.Add(DateTimeOffset.UtcNow);
-        Logger.Warning("Failed login attempt for {Username} from {IP}. Count (last {Window}): {Count}.", username, clientIp, FailedAttemptsWindow, info.FailedTimestamps.Count);
-        if (info.FailedTimestamps.Count >= MaxFailedAttempts)
+        var scope = isGlobal ? "account-global" : "per-IP";
+        Logger.Warning("Failed login attempt for {Username} from {IP} ({Scope}). Count (last {Window}): {Count}.", username, clientIp, scope, FailedAttemptsWindow, info.FailedTimestamps.Count);
+
+        if (info.FailedTimestamps.Count >= threshold && info.LockedUntil == null)
         {
-            info.LockedUntil = DateTimeOffset.UtcNow.Add(LockoutDuration);
-            Logger.Warning("Account {Username} from {IP} locked until {LockedUntil} after {Count} failed attempts.", username, clientIp, info.LockedUntil, info.FailedTimestamps.Count);
+            info.LockedUntil = DateTimeOffset.UtcNow.Add(lockoutDuration);
+            Logger.Warning("Account {Username} locked until {LockedUntil} after {Count} failed attempts ({Scope}).", username, info.LockedUntil, info.FailedTimestamps.Count, scope);
 
             _ = Logger.LogSecurityEventAsync(new SecurityEvent(
                 "Security.AccountLockout",
@@ -62,57 +118,24 @@ public class AccountLockoutService : IAccountLockoutService
                 clientIp,
                 null,
                 true,
-                new { username, threshold = MaxFailedAttempts, signal = "Too many failed attempts" }
+                new { username, threshold, scope, signal = "Too many failed attempts" }
             ));
         }
-        SetInfo(username, clientIp, info);
-        return Task.CompletedTask;
+        SetInfo(key, info);
     }
 
-    public Task ResetFailedAttemptsAsync(string username, string clientIp)
+    private LockoutInfo GetInfo(string key)
     {
-        var key = Key(username, clientIp);
-        _cache.Remove(key);
-        Logger.Information("Reset lockout counters for {Username} from {IP} after successful login.", username, clientIp);
-        return Task.CompletedTask;
-    }
-
-    public Task<TimeSpan?> GetLockoutTimeRemainingAsync(string username, string clientIp)
-    {
-        var info = GetInfo(username, clientIp);
-        CleanupWindow(info);
-        if (info.LockedUntil is { } until && until > DateTimeOffset.UtcNow)
-        {
-            return Task.FromResult<TimeSpan?>(until - DateTimeOffset.UtcNow);
-        }
-        return Task.FromResult<TimeSpan?>(null);
-    }
-
-    public Task UnlockAccountAsync(string username, string clientIp)
-    {
-        var key = Key(username, clientIp);
-        _cache.Remove(key);
-        Logger.Information("Manually unlocked account {Username} from {IP} by admin.", username, clientIp);
-        return Task.CompletedTask;
-    }
-
-    private LockoutInfo GetInfo(string username, string clientIp)
-    {
-        var key = Key(username, clientIp);
         if (!_cache.TryGetValue(key, out LockoutInfo? info) || info is null)
         {
             info = new LockoutInfo();
-            var options = new MemoryCacheEntryOptions()
-                .SetSlidingExpiration(TimeSpan.FromMinutes(30))
-                .SetAbsoluteExpiration(TimeSpan.FromHours(6));
-            _cache.Set(key, info, options);
+            SetInfo(key, info);
         }
         return info;
     }
 
-    private void SetInfo(string username, string clientIp, LockoutInfo info)
+    private void SetInfo(string key, LockoutInfo info)
     {
-        var key = Key(username, clientIp);
         var options = new MemoryCacheEntryOptions()
             .SetSlidingExpiration(TimeSpan.FromMinutes(30))
             .SetAbsoluteExpiration(TimeSpan.FromHours(6));

--- a/HedgehogPanel/Infrastructure/Security/ILockoutSettings.cs
+++ b/HedgehogPanel/Infrastructure/Security/ILockoutSettings.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace HedgehogPanel.Infrastructure.Security;
+
+/// <summary>
+/// Runtime-adjustable account-lockout policy: how many failed attempts trip the per-IP lockout and
+/// how long that lockout lasts. Admins change these values through the panel settings.
+/// </summary>
+public interface ILockoutSettings
+{
+    /// <summary>Number of failed attempts from a single IP that triggers a lockout.</summary>
+    int MaxFailedAttempts { get; }
+
+    /// <summary>How long a per-IP lockout lasts.</summary>
+    TimeSpan LockoutDuration { get; }
+
+    /// <summary>Applies new values (implementations clamp them to a safe range).</summary>
+    void Update(int maxFailedAttempts, int lockoutMinutes);
+}

--- a/HedgehogPanel/Infrastructure/Security/LockoutSettings.cs
+++ b/HedgehogPanel/Infrastructure/Security/LockoutSettings.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+namespace HedgehogPanel.Infrastructure.Security;
+
+/// <summary>
+/// Thread-safe, in-memory lockout policy. Editable at runtime by admins; resets to the defaults on
+/// restart (persisting it across restarts is tracked together with the rest of the lockout state).
+/// </summary>
+public sealed class LockoutSettings : ILockoutSettings
+{
+    public const int DefaultMaxFailedAttempts = 5;
+    public const int DefaultLockoutMinutes = 5;
+
+    private const int MinAttempts = 1;
+    private const int MaxAttempts = 100;
+    private const int MinMinutes = 1;
+    private const int MaxMinutes = 1440; // 24 hours
+
+    private int _maxFailedAttempts = DefaultMaxFailedAttempts;
+    private int _lockoutMinutes = DefaultLockoutMinutes;
+
+    public int MaxFailedAttempts => Volatile.Read(ref _maxFailedAttempts);
+
+    public TimeSpan LockoutDuration => TimeSpan.FromMinutes(Volatile.Read(ref _lockoutMinutes));
+
+    public void Update(int maxFailedAttempts, int lockoutMinutes)
+    {
+        Volatile.Write(ref _maxFailedAttempts, Math.Clamp(maxFailedAttempts, MinAttempts, MaxAttempts));
+        Volatile.Write(ref _lockoutMinutes, Math.Clamp(lockoutMinutes, MinMinutes, MaxMinutes));
+    }
+}

--- a/HedgehogPanel/Web/wwwroot/js/admin-pages.js
+++ b/HedgehogPanel/Web/wwwroot/js/admin-pages.js
@@ -623,12 +623,39 @@ const AdminSettingsPage = ({
   const [palette, setPalette] = React.useState(defaults.palette);
   const [defaultLang, setDefaultLang] = React.useState(defaults.lang);
   const [saved, setSaved] = React.useState(false);
-  const save = e => {
+  const [maxFails, setMaxFails] = React.useState("5");
+  const [lockMinutes, setLockMinutes] = React.useState("5");
+
+  React.useEffect(() => {
+    fetch("/api/admin/settings/lockout", {
+      credentials: "same-origin"
+    }).then(r => r.ok ? r.json() : null).then(d => {
+      if (!d) return;
+      setMaxFails(String(d.maxFailedAttempts));
+      setLockMinutes(String(d.lockoutMinutes));
+    }).catch(() => {});
+  }, []);
+  const save = async e => {
     e.preventDefault();
     onChangeDefaults?.({
       palette,
       lang: defaultLang
     });
+    try {
+      const csrf = (document.cookie.split("; ").find(r => r.startsWith("XSRF-TOKEN=")) || "=").split("=").slice(1).join("=");
+      await fetch("/api/admin/settings/lockout", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": csrf
+        },
+        credentials: "same-origin",
+        body: JSON.stringify({
+          maxFailedAttempts: parseInt(maxFails, 10) || 5,
+          lockoutMinutes: parseInt(lockMinutes, 10) || 5
+        })
+      });
+    } catch (err) {/* ignore network error; local defaults are still applied */}
     setSaved(true);
     setTimeout(() => setSaved(false), 2500);
   };
@@ -767,12 +794,20 @@ const AdminSettingsPage = ({
     className: "field"
   }, /*#__PURE__*/React.createElement("label", null, t("admin.settings.max_fails")), /*#__PURE__*/React.createElement("input", {
     className: "input",
-    defaultValue: "5"
+    type: "number",
+    min: "1",
+    max: "100",
+    value: maxFails,
+    onChange: e => setMaxFails(e.target.value)
   })), /*#__PURE__*/React.createElement("div", {
     className: "field"
   }, /*#__PURE__*/React.createElement("label", null, t("admin.settings.lock_minutes")), /*#__PURE__*/React.createElement("input", {
     className: "input",
-    defaultValue: "15"
+    type: "number",
+    min: "1",
+    max: "1440",
+    value: lockMinutes,
+    onChange: e => setLockMinutes(e.target.value)
   })))), /*#__PURE__*/React.createElement("div", {
     style: {
       display: "flex",


### PR DESCRIPTION
### Summary
Strengthens the brute-force protections and makes the lockout policy adjustable from the admin panel.

Three things:
1. **Double-count bug** — on a wrong password, `AuthEndpoints` recorded the failed attempt **twice** (once in the `account == null` branch, once in the `catch`), so accounts locked in roughly half the configured attempts.
2. **Per-IP only** — lockout was keyed by `username|ip`, so a distributed attacker got a fresh attempt budget per source IP against one account.
3. **Hardcoded thresholds** — max attempts / lockout duration were compile-time constants; the Panel Settings form showed inputs but saving did nothing.

### Backend
- **`AuthEndpoints`**: removed the duplicate `RecordFailedAttemptAsync` call — a failed attempt is now recorded exactly once (in the `catch`).
- **`AccountLockoutService`**: added an **account-global** counter (`lockout-global:{user}`) alongside the existing per-IP one.
  - `RecordFailedAttemptAsync` increments both buckets; `IsAccountLockedAsync` / `GetLockoutTimeRemainingAsync` consider both (locked if either is locked; returns the later expiry).
  - A successful login clears only the per-IP counter (the global one expires on its own, so one guessed password can't wipe a distributed-attack ceiling); admin unlock clears both.
  - The per-IP threshold and lockout duration are now read from `ILockoutSettings`; the 15-minute window and the account-global limits (15 attempts / 15 min) remain internal constants.
- **`ILockoutSettings` / `LockoutSettings`**: thread-safe, runtime-adjustable holder for `MaxFailedAttempts` + `LockoutDuration` (values clamped: 1–100 attempts, 1–1440 min). Registered as a singleton so changes persist across requests.
- **Endpoints** (admin-only): `GET /api/admin/settings/lockout` and `PUT /api/admin/settings/lockout` (validates, applies, and audits via `Security.LockoutSettingsUpdated`).

### Frontend
- `admin-pages.js`: the **Panel Settings → Account lockout** form now loads the current values from the API on open, uses controlled number inputs, and **PUTs the new policy on Save** (with CSRF) — so changes take effect immediately on subsequent failed logins.

### Testing
- `AccountLockoutServiceTests`: adjusted for the new behavior and added real-cache tests for per-IP isolation and the multi-IP account-global throttle — **passing**.
- `LoginFailureCountTests` (integration): a wrong password increments by exactly one, so the account locks on the 5th failure (regression guard for the double-count fix).
- Solution builds clean; the settings form was smoke-tested end-to-end in the running app.

### Out of scope / follow-up
- The lockout state and the adjustable settings are **in-memory** — they reset on restart.

### Acceptance criteria
- [x] A single wrong password increments the counter by exactly one (regression test).
- [x] A targeted account is throttled even when attempts come from many IPs.
- [x] The lockout policy can be changed from the admin UI and takes effect.